### PR TITLE
Updated to fix setAssociationGroup

### DIFF
--- a/Drivers/inovelli-1-channel-outdoor-smart-plug-nzw96.src/inovelli-1-channel-outdoor-smart-plug-nzw96.groovy
+++ b/Drivers/inovelli-1-channel-outdoor-smart-plug-nzw96.src/inovelli-1-channel-outdoor-smart-plug-nzw96.groovy
@@ -1,7 +1,4 @@
 /**
- *
- *  Hubitat Import URL: https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-1-channel-outdoor-smart-plug-nzw96.src/inovelli-1-channel-outdoor-smart-plug-nzw96.groovy
- *
  *  Inovelli 1-Channel Outdoor Smart Plug NZW96
  *  Author: Eric Maycock (erocm123)
  *  Date: 2018-02-15
@@ -20,7 +17,12 @@
  */
  
 metadata {
-    definition (name: "Inovelli 1-Channel Outdoor Smart Plug NZW96", namespace: "InovelliUSA", author: "Eric Maycock") {
+    definition (
+        name: "Inovelli 1-Channel Outdoor Smart Plug NZW96",
+        namespace: "InovelliUSA",
+        author: "Eric Maycock",
+        importUrl: "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-1-channel-outdoor-smart-plug-nzw96.src/inovelli-1-channel-outdoor-smart-plug-nzw96.groovy"
+    ) {
         capability "Switch"
         capability "Refresh"
         capability "Polling"

--- a/Drivers/inovelli-1-channel-smart-plug-nzw36-w-scene.src/inovelli-1-channel-smart-plug-nzw36-w-scene.groovy
+++ b/Drivers/inovelli-1-channel-smart-plug-nzw36-w-scene.src/inovelli-1-channel-smart-plug-nzw36-w-scene.groovy
@@ -1,7 +1,4 @@
 /**
- *
- *  Hubitat Import URL: https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-1-channel-smart-plug-nzw36-w-scene.src/inovelli-1-channel-smart-plug-nzw36-w-scene.groovy
- *
  *  Inovelli 1-Channel Smart Plug NZW36 w/Scene
  *  Author: Eric Maycock (erocm123)
  *  Date: 2017-09-19
@@ -20,7 +17,12 @@
  */
  
 metadata {
-    definition (name: "Inovelli 1-Channel Smart Plug NZW36 w/Scene", namespace: "InovelliUSA", author: "Eric Maycock") {
+    definition (
+        name: "Inovelli 1-Channel Smart Plug NZW36 w/Scene", 
+        namespace: "InovelliUSA", 
+        author: "Eric Maycock",
+        importUrl: "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-1-channel-smart-plug-nzw36-w-scene.src/inovelli-1-channel-smart-plug-nzw36-w-scene.groovy"
+    ) {
         capability "Switch"
         capability "Refresh"
         capability "Polling"

--- a/Drivers/inovelli-2-channel-outdoor-smart-plug-nzw97.src/inovelli-2-channel-outdoor-smart-plug-nzw97.groovy
+++ b/Drivers/inovelli-2-channel-outdoor-smart-plug-nzw97.src/inovelli-2-channel-outdoor-smart-plug-nzw97.groovy
@@ -1,7 +1,4 @@
 /**
- *
- *  Hubitat Import URL: https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-2-channel-outdoor-smart-plug-nzw97.src/inovelli-2-channel-outdoor-smart-plug-nzw97.groovy
- *
  *  Inovelli 2-Channel Outdoor Smart Plug NZW97
  *  Author: Eric Maycock (erocm123)
  *  Date: 2018-05-02
@@ -17,12 +14,19 @@
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
  *
+ *  2019-11-20: Fixed Association Group management.
+ *
  *  2018-05-02: Added support for Z-Wave Association Tool SmartApp. Associations require firmware 1.02+.
  *              https://github.com/erocm123/SmartThingsPublic/tree/master/smartapps/erocm123/z-waveat
  */
  
 metadata {
-    definition(name: "Inovelli 2-Channel Outdoor Smart Plug NZW97", namespace: "InovelliUSA", author: "Eric Maycock") {
+    definition(
+        name: "Inovelli 2-Channel Outdoor Smart Plug NZW97", 
+        namespace: "InovelliUSA", 
+        author: "Eric Maycock",
+        importUrl: "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-2-channel-outdoor-smart-plug-nzw97.src/inovelli-2-channel-outdoor-smart-plug-nzw97.groovy"
+    ) {
         capability "Actuator"
         capability "Sensor"
         capability "Switch"
@@ -35,7 +39,11 @@ metadata {
         attribute "lastActivity", "String"
         attribute "lastEvent", "String"
         
-        command "setAssociationGroup", ["number", "enum", "number", "number"] // group number, nodes, action (0 - remove, 1 - add), multi-channel endpoint (optional)
+        command "setAssociationGroup", [[name: "Group Number*",type:"NUMBER", description: "Provide the association group number to edit"], 
+                                        [name: "Z-Wave Node*", type:"STRING", description: "Enter the node number (in hex) associated with the node"], 
+                                        [name: "Action*", type:"ENUM", constraints: ["Add", "Remove"]],
+                                        [name:"Multi-channel Endpoint", type:"NUMBER", description: "Currently not implemented"]] 
+
         command "childOn"
         command "childOff"
         command "childRefresh"
@@ -125,16 +133,6 @@ def zwaveEvent(hubitat.zwave.commands.basicv1.BasicReport cmd, ep = null) {
         }
         return event
     }
-}
-
-def zwaveEvent(hubitat.zwave.commands.basicv1.BasicSet cmd) {
-    log.debug "BasicSet ${cmd}"
-    def result = createEvent(name: "switch", value: cmd.value ? "on" : "off", type: "digital")
-    def cmds = []
-    cmds << encap(zwave.switchBinaryV1.switchBinaryGet(), 1)
-    cmds << encap(zwave.switchBinaryV1.switchBinaryGet(), 2)
-    //return [result, response(commands(cmds))] // returns the result of reponse()
-    return response(commands(cmds)) // returns the result of reponse()
 }
 
 def zwaveEvent(hubitat.zwave.commands.switchbinaryv1.SwitchBinaryReport cmd, ep = null) {
@@ -367,56 +365,63 @@ private void createChildDevices() {
 }
 
 def setDefaultAssociations() {
-    def smartThingsHubID = zwaveHubNodeId.toString().format( '%02x', zwaveHubNodeId )
+    def smartThingsHubID = String.format('%02x', zwaveHubNodeId).toUpperCase()
     state.defaultG1 = [smartThingsHubID]
-    state.defaultG2 = [smartThingsHubID]
+    state.defaultG2 = []
     state.defaultG3 = []
 }
 
-def setAssociationGroup(group, nodes, action, endpoint = null){
-    if (!state."desiredAssociation${group}") {
-        state."desiredAssociation${group}" = nodes
-    } else {
-        switch (action) {
-            case 0:
-                state."desiredAssociation${group}" = state."desiredAssociation${group}" - nodes
-            break
-            case 1:
-                state."desiredAssociation${group}" = state."desiredAssociation${group}" + nodes
-            break
-        }
+def setAssociationGroup(group, node, action, endpoint = null){
+    if (! node =~ /[0-9A-F]+/)
+        return
+
+    if (group < 1 || group > maxAssociationGroup())
+        return
+    
+    def associations = state."desiredAssociation${group}"?:[]
+    switch (action) {
+        case "Remove":
+        associations = associations - node
+        break
+        case "Add":
+        associations << node
+        break
     }
+    state."desiredAssociation${group}" = associations.unique()
+    return
+}
+
+def maxAssociationGroup(){
+   if (!state.associationGroups) {
+       if (logEnable) log.debug "Getting supported association groups from device"
+       zwave.associationV2.associationGroupingsGet() // execute the update immediately
+   }
+   (state.associationGroups?: 5) as int
 }
 
 def processAssociations(){
    def cmds = []
    setDefaultAssociations()
-   def associationGroups = 5
-   if (state.associationGroups) {
-       associationGroups = state.associationGroups
-   } else {
-       log.debug "Getting supported association groups from device"
-       cmds <<  zwave.associationV2.associationGroupingsGet()
-   }
+   def associationGroups = maxAssociationGroup()
    for (int i = 1; i <= associationGroups; i++){
       if(state."actualAssociation${i}" != null){
          if(state."desiredAssociation${i}" != null || state."defaultG${i}") {
             def refreshGroup = false
             ((state."desiredAssociation${i}"? state."desiredAssociation${i}" : [] + state."defaultG${i}") - state."actualAssociation${i}").each {
-                log.debug "Adding node $it to group $i"
-                cmds << zwave.associationV2.associationSet(groupingIdentifier:i, nodeId:Integer.parseInt(it,16))
+                if (logEnable) log.debug "Adding node $it to group $i"
+                cmds << zwave.associationV2.associationSet(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
                 refreshGroup = true
             }
             ((state."actualAssociation${i}" - state."defaultG${i}") - state."desiredAssociation${i}").each {
-                log.debug "Removing node $it from group $i"
-                cmds << zwave.associationV2.associationRemove(groupingIdentifier:i, nodeId:Integer.parseInt(it,16))
+                if (logEnable) log.debug "Removing node $it from group $i"
+                cmds << zwave.associationV2.associationRemove(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
                 refreshGroup = true
             }
             if (refreshGroup == true) cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
-            else log.debug "There are no association actions to complete for group $i"
+            else if (logEnable) log.debug "There are no association actions to complete for group $i"
          }
       } else {
-         log.debug "Association info not known for group $i. Requesting info from device."
+         if (logEnable) log.debug "Association info not known for group $i. Requesting info from device."
          cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
       }
    }

--- a/Drivers/inovelli-2-channel-outdoor-smart-plug-nzw97.src/inovelli-2-channel-outdoor-smart-plug-nzw97.groovy
+++ b/Drivers/inovelli-2-channel-outdoor-smart-plug-nzw97.src/inovelli-2-channel-outdoor-smart-plug-nzw97.groovy
@@ -371,21 +371,35 @@ def setDefaultAssociations() {
     state.defaultG3 = []
 }
 
-def setAssociationGroup(group, node, action, endpoint = null){
-    if (! node =~ /[0-9A-F]+/)
-        return
+def setAssociationGroup(group, nodes, action, endpoint = null){
+    // Normalize the arguments to be backwards compatible with the old method
+    action = "${action}" == "1" ? "Add" : "${action}" == "0" ? "Remove" : "${action}" // convert 1/0 to Add/Remove
+    group  = "${group}" =~ /\d+/ ? (group as int) : group                             // convert group to int (if possible)
+    nodes  = [] + nodes ?: [nodes]                                                    // convert to collection if not already a collection
 
-    if (group < 1 || group > maxAssociationGroup())
+    if (! nodes.every { it =~ /[0-9A-F]+/ }) {
+        log.error "invalid Nodes ${nodes}"
         return
+    }
+
+    if (group < 1 || group > maxAssociationGroup()) {
+        log.error "Association group is invalid 1 <= ${group} <= ${maxAssociationGroup()}"
+        return
+    }
     
     def associations = state."desiredAssociation${group}"?:[]
-    switch (action) {
-        case "Remove":
-        associations = associations - node
-        break
-        case "Add":
-        associations << node
-        break
+    nodes.each { 
+        node = "${it}"
+        switch (action) {
+            case "Remove":
+            if (logEnable) log.debug "Removing node ${node} from association group ${group}"
+            associations = associations - node
+            break
+            case "Add":
+            if (logEnable) log.debug "Adding node ${node} to association group ${group}"
+            associations << node
+            break
+        }
     }
     state."desiredAssociation${group}" = associations.unique()
     return

--- a/Drivers/inovelli-dimmer-lzw31.src/inovelli-dimmer-lzw31.groovy
+++ b/Drivers/inovelli-dimmer-lzw31.src/inovelli-dimmer-lzw31.groovy
@@ -722,21 +722,35 @@ def setDefaultAssociations() {
     state.defaultG3 = []
 }
 
-def setAssociationGroup(group, node, action, endpoint = null){
-    if (! node =~ /[0-9A-F]+/)
-        return
+def setAssociationGroup(group, nodes, action, endpoint = null){
+    // Normalize the arguments to be backwards compatible with the old method
+    action = "${action}" == "1" ? "Add" : "${action}" == "0" ? "Remove" : "${action}" // convert 1/0 to Add/Remove
+    group  = "${group}" =~ /\d+/ ? (group as int) : group                             // convert group to int (if possible)
+    nodes  = [] + nodes ?: [nodes]                                                    // convert to collection if not already a collection
 
-    if (group < 1 || group > maxAssociationGroup())
+    if (! nodes.every { it =~ /[0-9A-F]+/ }) {
+        log.error "invalid Nodes ${nodes}"
         return
+    }
+
+    if (group < 1 || group > maxAssociationGroup()) {
+        log.error "Association group is invalid 1 <= ${group} <= ${maxAssociationGroup()}"
+        return
+    }
     
     def associations = state."desiredAssociation${group}"?:[]
-    switch (action) {
-        case "Remove":
-        associations = associations - node
-        break
-        case "Add":
-        associations << node
-        break
+    nodes.each { 
+        node = "${it}"
+        switch (action) {
+            case "Remove":
+            if (logEnable) log.debug "Removing node ${node} from association group ${group}"
+            associations = associations - node
+            break
+            case "Add":
+            if (logEnable) log.debug "Adding node ${node} to association group ${group}"
+            associations << node
+            break
+        }
     }
     state."desiredAssociation${group}" = associations.unique()
     return

--- a/Drivers/inovelli-dimmer-lzw31.src/inovelli-dimmer-lzw31.groovy
+++ b/Drivers/inovelli-dimmer-lzw31.src/inovelli-dimmer-lzw31.groovy
@@ -1,0 +1,817 @@
+/**
+ *  Inovelli Dimmer LZW31
+ *  Author: Eric Maycock (erocm123)
+ *  Date: 2019-11-13
+ *
+ *  Copyright 2019 Eric Maycock / Inovelli
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ *  2019-11-20: Fixed Association Group management.
+ *
+ *  2019-11-13: Bug fix for not being able to set default level back to 0
+ */
+ 
+metadata {
+    definition (name: "Inovelli Dimmer LZW31", namespace: "InovelliUSA", author: "Eric Maycock", vid: "generic-dimmer", importUrl:"https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-dimmer-lzw31.src/inovelli-dimmer-lzw31.groovy") {
+        capability "Switch"
+        capability "Refresh"
+        capability "Polling"
+        capability "Actuator"
+        capability "Sensor"
+        //capability "Health Check"
+        capability "Switch Level"
+        capability "Configuration"
+        
+        attribute "lastActivity", "String"
+        attribute "lastEvent", "String"
+        attribute "firmware", "String"
+        
+        command "reset"
+        command "setAssociationGroup", [[name: "Group Number*",type:"NUMBER", description: "Provide the association group number to edit"], 
+                                        [name: "Z-Wave Node*", type:"STRING", description: "Enter the node number (in hex) associated with the node"], 
+                                        [name: "Action*", type:"ENUM", constraints: ["Add", "Remove"]],
+                                        [name:"Multi-channel Endpoint", type:"NUMBER", description: "Currently not implemented"]] 
+
+        fingerprint mfr: "031E", prod: "0003", model: "0001", deviceJoinName: "Inovelli Dimmer"
+        fingerprint deviceId: "0x1101", inClusters: "0x5E,0x55,0x98,0x9F,0x6C,0x22,0x26,0x70,0x85,0x59,0x86,0x72,0x5A,0x73,0x75,0x7A" 
+        fingerprint deviceId: "0x1101", inClusters: "0x5E,0x26,0x70,0x85,0x59,0x55,0x86,0x72,0x5A,0x73,0x98,0x9F,0x6C,0x75,0x22,0x7A" 
+    }
+
+    simulator {
+    }
+    
+    preferences {
+        generate_preferences()
+    }
+
+}
+
+def generate_preferences()
+{
+    getParameterNumbers().each { i ->
+        
+        switch(getParameterInfo(i, "type"))
+        {   
+            case "number":
+                input "parameter${i}", "number",
+                    title:getParameterInfo(i, "name") + "\n" + getParameterInfo(i, "description") + "\nRange: " + getParameterInfo(i, "options") + "\nDefault: " + getParameterInfo(i, "default"),
+                    range: getParameterInfo(i, "options")
+                    //defaultValue: getParameterInfo(i, "default")
+                    //displayDuringSetup: "${it.@displayDuringSetup}"
+            break
+            case "enum":
+                input "parameter${i}", "enum",
+                    title:getParameterInfo(i, "name"), // + getParameterInfo(i, "description"),
+                    //defaultValue: getParameterInfo(i, "default"),
+                    //displayDuringSetup: "${it.@displayDuringSetup}",
+                    options: getParameterInfo(i, "options")
+            break
+        }  
+    }
+    
+    input "disableLocal", "enum", title: "Disable Local Control\n\nDisable ability to control switch from the wall", description: "Tap to set", required: false, options:[["1": "Yes"], ["0": "No"]], defaultValue: "0"
+}
+
+private channelNumber(String dni) {
+    dni.split("-ep")[-1] as Integer
+}
+
+private sendAlert(data) {
+    sendEvent(
+        descriptionText: data.message,
+        eventType: "ALERT",
+        name: "failedOperation",
+        value: "failed",
+        displayed: true,
+    )
+}
+
+def childSetLevel(String dni, value) {
+    def valueaux = value as Integer
+    def level = Math.max(Math.min(valueaux, 99), 0)    
+    def cmds = []
+    switch (channelNumber(dni)) {
+        case 101:
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionSet(localProtectionState : level > 0 ? 1 : 0, rfProtectionState: state.rfProtectionState? state.rfProtectionState:0) ), hubitat.device.Protocol.ZWAVE)
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionGet() ), hubitat.device.Protocol.ZWAVE)
+        break
+        case 102:
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionSet(localProtectionState : state.localProtectionState? state.localProtectionState:0, rfProtectionState : level > 0 ? 1 : 0) ), hubitat.device.Protocol.ZWAVE)
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionGet() ), hubitat.device.Protocol.ZWAVE)
+        break
+    }
+	return cmds
+}
+
+private toggleTiles(number, value) {
+   for (int i = 1; i <= 5; i++){
+       if ("${i}" != number){
+           def childDevice = childDevices.find{it.deviceNetworkId == "$device.deviceNetworkId-ep$i"}
+           if (childDevice) {         
+                childDevice.sendEvent(name: "switch", value: "off")
+           }
+       } else {
+           def childDevice = childDevices.find{it.deviceNetworkId == "$device.deviceNetworkId-ep$i"}
+           if (childDevice) {         
+                childDevice.sendEvent(name: "switch", value: value)
+           }
+       }
+   }
+}
+
+def childOn(String dni) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: childOn($dni)"
+    def cmds = []
+    if(channelNumber(dni).toInteger() <= 5) {
+        toggleTiles("${channelNumber(dni)}", "on")
+        cmds << new hubitat.device.HubAction(command(setParameter(8, calculateParameter("8-${channelNumber(dni)}"), 4)), hubitat.device.Protocol.ZWAVE )
+        return cmds
+    } else {
+        childSetLevel(dni, 99)
+    }
+}
+
+def childOff(String dni) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: childOff($dni)"
+    def cmds = []
+    if(channelNumber(dni).toInteger() <= 5) {
+        toggleTiles("${channelNumber(dni)}", "off")
+        cmds << new hubitat.device.HubAction(command(setParameter(8, 0, 4)), hubitat.device.Protocol.ZWAVE )
+        return cmds
+    } else {
+        childSetLevel(dni, 0)
+    }
+}
+
+void childRefresh(String dni) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: childRefresh($dni)"
+}
+
+
+def childExists(ep) {
+    def children = childDevices
+    def childDevice = children.find{it.deviceNetworkId.endsWith(ep)}
+    if (childDevice) 
+        return true
+    else
+        return false
+}
+
+def installed() {
+    log.debug "installed()"
+    refresh()
+}
+
+def configure() {
+    log.debug "configure()"
+    def cmds = initialize()
+    commands(cmds)
+}
+
+def updated() {
+    if (!state.lastRan || now() >= state.lastRan + 2000) {
+        log.debug "updated()"
+        state.lastRan = now()
+        def cmds = initialize()
+        if (cmds != [])
+            commands(cmds, 1000)
+        else 
+            return null
+    } else {
+        log.debug "updated() ran within the last 2 seconds. Skipping execution."
+    }
+}
+
+def initialize() {
+    sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
+    sendEvent(name: "numberOfButtons", value: 7, displayed: true)
+    
+    if (enableDefaultLocalChild && !childExists("ep8")) {
+    try {
+        addChildDevice("Switch Level Child Device", "${device.deviceNetworkId}-ep8", 
+                [completedSetup: true, label: "${device.displayName} (Default Local Level)",
+                isComponent: true, componentName: "ep8", componentLabel: "Default Local Level"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
+    }
+    } else if (!enableDefaultLocalChild && childExists("ep8")) {
+        log.debug "Trying to delete child device ep8. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep8")}
+        try {
+            log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }
+    if (enableDefaultZWaveChild && !childExists("ep9")) {
+    try {
+        addChildDevice("Switch Level Child Device", "${device.deviceNetworkId}-ep9", 
+                [completedSetup: true, label: "${device.displayName} (Default Z-Wave Level)",
+                isComponent: true, componentName: "ep9", componentLabel: "Default Z-Wave Level"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
+    }
+    } else if (!enableDefaultLocalChild && childExists("ep9")) {
+        log.debug "Trying to delete child device ep9. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep9")}
+        try {
+            log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }
+    if (enableDisableLocalChild && !childExists("ep101")) {
+    try {
+        addChildDevice("Switch Level Child Device", "${device.deviceNetworkId}-ep101", 
+                [completedSetup: true, label: "${device.displayName} (Disable Local Control)",
+                isComponent: true, componentName: "ep101", componentLabel: "Disable Local Control"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
+    }
+    } else if (!enableDisableLocalChild && childExists("ep101")) {
+        log.debug "Trying to delete child device ep101. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
+        try {
+            log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }
+    [1,2,3,4].each { i ->
+    if ((settings."parameter16-${i}a"!=null && settings."parameter16-${i}b"!=null && settings."parameter16-${i}c"!=null && settings."parameter16-${i}d"!=null) && !childExists("ep${i}")) {
+    try {
+        addChildDevice("Switch Child Device", "${device.deviceNetworkId}-ep${i}", 
+                [completedSetup: true, label: "${device.displayName} (Notification ${i})",
+                isComponent: true, componentName: "ep${i}", componentLabel: "Notification ${i}"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Child Device\" is installed"]])
+    }
+    } else if ((settings."parameter16-${i}a"==null || settings."parameter16-${i}b"==null || settings."parameter16-${i}c"==null || settings."parameter16-${i}d"==null) && childExists("ep${i}")) {
+        log.debug "Trying to delete child device ep${i}. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep${i}")}
+        try {
+            log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }}
+    if (device.label != state.oldLabel) {
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep1")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Notification 1)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep2")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Notification 2)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep3")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Notification 3)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep4")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Notification 1)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep8")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Default Local Level)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep9")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Default Z-Wave Level)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Disable Local Control)")
+        state.oldLabel = device.label
+    }
+
+    sendEvent([name:"pressUpX1", value:pressUpX1Label? "${pressUpX1Label} ▲" : "Tap ▲", displayed: false])
+    sendEvent([name:"pressDownX1", value:pressDownX1Label? "${pressDownX1Label} ▼" : "Tap ▼", displayed: false])
+    sendEvent([name:"pressUpX2", value:pressUpX2Label? "${pressUpX2Label} ▲▲" : "Tap ▲▲", displayed: false])
+    sendEvent([name:"pressDownX2", value:pressDownX2Label? "${pressDownX2Label} ▼▼" : "Tap ▼▼", displayed: false])
+    sendEvent([name:"pressUpX3", value:pressUpX3Label? "${pressUpX3Label} ▲▲▲" : "Tap ▲▲▲", displayed: false])
+    sendEvent([name:"pressDownX3", value:pressDownX3Label? "${pressDownX3Label} ▼▼▼" : "Tap ▼▼▼", displayed: false])
+    sendEvent([name:"pressUpX4", value:pressUpX4Label? "${pressUpX4Label} ▲▲▲▲" : "Tap ▲▲▲▲", displayed: false])
+    sendEvent([name:"pressDownX4", value:pressDownX4Label? "${pressDownX4Label} ▼▼▼▼" : "Tap ▼▼▼▼", displayed: false])
+    sendEvent([name:"pressUpX5", value:pressUpX5Label? "${pressUpX5Label} ▲▲▲▲▲" : "Tap ▲▲▲▲▲", displayed: false])
+    sendEvent([name:"pressDownX5", value:pressDownX5Label? "${pressDownX5Label} ▼▼▼▼▼" : "Tap ▼▼▼▼▼", displayed: false])
+    sendEvent([name:"holdUp", value:pressHoldUpLabel? "${pressHoldUpLabel} ▲" : "Hold ▲", displayed: false])
+    sendEvent([name:"holdDown", value:pressHoldDownLabel? "${pressHoldDownLabel} ▼" : "Hold ▼", displayed: false])
+    
+    def cmds = processAssociations()
+    
+    getParameterNumbers().each{ i ->
+      //log.debug "$i: ${state."parameter${i}value"}"
+      if ((state."parameter${i}value" != (settings."parameter${i}"!=null? calculateParameter(i).toInteger() : getParameterInfo(i, "default").toInteger())) || i == 16){
+          //log.debug "Parameter $i is not set correctly. Setting it to ${settings."parameter${i}"!=null? calculateParameter(i).toInteger() : getParameterInfo(i, "default").toInteger()}."
+          cmds << setParameter(i, settings."parameter${i}"!=null? calculateParameter(i).toInteger() : getParameterInfo(i, "default").toInteger(), getParameterInfo(i, "size").toInteger())
+          cmds << getParameter(i)
+      }
+      else {
+          //log.debug "Parameter already set"
+      }
+    }
+    
+    cmds << zwave.versionV1.versionGet()
+    if (state.disableLocal != settings.disableLocal) {
+        cmds << zwave.protectionV2.protectionSet(localProtectionState : disableLocal!=null? disableLocal.toInteger() : 0, rfProtectionState: disableRemote!=null? disableRemote.toInteger() : 0)
+        cmds << zwave.protectionV2.protectionGet()
+    }
+
+    state.defaultLocal = settings.defaultLocal
+    state.defaultZWave = settings.defaultZWave
+    state.disableLocal = settings.disableLocal
+    if (cmds != []) return cmds else return []
+}
+
+def calculateParameter(number) {
+    def value = 0
+    switch (number){
+      case "16-1":
+      case "16-2":
+      case "16-3": 
+      case "16-4":
+         value += settings."parameter${number}a"!=null ? settings."parameter${number}a".toInteger() * 1 : 0
+         value += settings."parameter${number}b"!=null ? settings."parameter${number}b".toInteger() * 256 : 0
+         value += settings."parameter${number}c"!=null ? settings."parameter${number}c".toInteger() * 65536 : 0
+         value += settings."parameter${number}d"!=null ? settings."parameter${number}d".toInteger() * 16777216 : 0
+      break
+      default:
+          value = settings."parameter${number}"
+      break
+    }
+    return value
+}
+
+def setParameter(number, value, size) {
+    log.debug "Setting parameter $number with a size of $size bytes to $value"
+    return zwave.configurationV1.configurationSet(configurationValue: integer2Cmd(value.toInteger(),size), parameterNumber: number, size: size)
+}
+
+def getParameter(number) {
+    //log.debug "Setting parameter $number with a size of $size bytes to $value"
+    return zwave.configurationV1.configurationGet(parameterNumber: number)
+}
+def getParameterNumbers(){
+    return [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,17,21,22]
+}
+
+def getParameterInfo(number, value){
+    def parameter = [:]
+    
+    parameter.parameter1default=3
+    parameter.parameter2default=101
+    parameter.parameter3default=101
+    parameter.parameter4default=101
+    parameter.parameter5default=1
+    parameter.parameter6default=99
+    parameter.parameter7default=0
+    parameter.parameter8default=0
+    parameter.parameter9default=0
+    parameter.parameter10default=0
+    parameter.parameter11default=0
+    parameter.parameter12default=15
+    parameter.parameter13default=170
+    parameter.parameter14default=5
+    parameter.parameter15default=1
+    parameter.parameter16default=0
+    parameter.parameter17default=3
+    parameter.parameter18default=10
+    parameter.parameter19default=3600
+    parameter.parameter20default=10
+    parameter.parameter21default=1
+    parameter.parameter22default=0
+    
+    parameter.parameter1type="number"
+    parameter.parameter2type="number"
+    parameter.parameter3type="number"
+    parameter.parameter4type="number"
+    parameter.parameter5type="number"
+    parameter.parameter6type="number"
+    parameter.parameter7type="enum"
+    parameter.parameter8type="number"
+    parameter.parameter9type="number"
+    parameter.parameter10type="number"
+    parameter.parameter11type="number"
+    parameter.parameter12type="number"
+    parameter.parameter13type="enum"
+    parameter.parameter14type="enum"
+    parameter.parameter15type="enum"
+    parameter.parameter16type="enum"
+    parameter.parameter17type="enum"
+    parameter.parameter18type="number"
+    parameter.parameter19type="number"
+    parameter.parameter20type="number"
+    parameter.parameter21type="enum"
+    parameter.parameter22type="enum"
+    
+    parameter.parameter1size=1
+    parameter.parameter2size=1
+    parameter.parameter3size=1
+    parameter.parameter4size=1
+    parameter.parameter5size=1
+    parameter.parameter6size=1
+    parameter.parameter7size=1
+    parameter.parameter8size=2
+    parameter.parameter9size=1
+    parameter.parameter10size=1
+    parameter.parameter11size=1
+    parameter.parameter12size=1
+    parameter.parameter13size=2
+    parameter.parameter14size=1
+    parameter.parameter15size=1
+    parameter.parameter16size=4
+    parameter.parameter17size=1
+    parameter.parameter18size=1
+    parameter.parameter19size=2
+    parameter.parameter20size=1
+    parameter.parameter21size=1
+    parameter.parameter22size=1
+    
+    parameter.parameter1options="0..100"
+    parameter.parameter2options="0..101"
+    parameter.parameter3options="0..101"
+    parameter.parameter4options="0..101"
+    parameter.parameter5options="1..45"
+    parameter.parameter6options="55..99"
+    parameter.parameter7options=["1":"Yes", "0":"No"]
+    parameter.parameter8options="0..32767"
+    parameter.parameter9options="0..100"
+    parameter.parameter10options="0..100"
+    parameter.parameter11options="0..100"
+    parameter.parameter12options="0..15"
+    parameter.parameter13options=["0":"Red","21":"Orange","42":"Yellow","85":"Green","127":"Cyan","170":"Blue","212":"Violet","234":"Pink"]
+    parameter.parameter14options=["0":"0%","1":"10%","2":"20%","3":"30%","4":"40%","5":"50%","6":"60%","7":"70%","8":"80%","9":"90%","10":"100%"]
+    parameter.parameter15options=["0":"0%","1":"10%","2":"20%","3":"30%","4":"40%","5":"50%","6":"60%","7":"70%","8":"80%","9":"90%","10":"100%"]
+    parameter.parameter16options=["1":"Yes", "2":"No"]
+    parameter.parameter17options=["0":"Stay Off","1":"1 Second","2":"2 Seconds","3":"3 Seconds","4":"4 Seconds","5":"5 Seconds","6":"6 Seconds","7":"7 Seconds","8":"8 Seconds","9":"9 Seconds","10":"10 Seconds"]
+    parameter.parameter18options="0..100"
+    parameter.parameter19options="0..32767"
+    parameter.parameter20options="0..100"
+    parameter.parameter21options=["0":"Non Neutral", "1":"Neutral"]
+    parameter.parameter22options=["0":"Load Only", "1":"3-way Toggle", "2":"3-way Momentary"]
+    
+    parameter.parameter1name="Dimming Speed"
+    parameter.parameter2name="Dimming Speed (From Switch)"
+    parameter.parameter3name="Ramp Rate"
+    parameter.parameter4name="Ramp Rate (From Switch)"
+    parameter.parameter5name="Minimum Level"
+    parameter.parameter6name="Maximum Level"
+    parameter.parameter7name="Invert Switch"
+    parameter.parameter8name="Auto Off Timer"
+    parameter.parameter9name="Default Level (Local)"
+    parameter.parameter10name="Default Level (Z-Wave)"
+    parameter.parameter11name="State After Power Restored"
+    parameter.parameter12name="Association Behavior"
+    parameter.parameter13name="LED Strip Color"
+    parameter.parameter14name="LED Strip Intensity"
+    parameter.parameter15name="LED Strip Intensity (When OFF)"
+    parameter.parameter16name="LED Strip Effect"
+    parameter.parameter17name="LED Strip Timeout"
+    parameter.parameter18name="Active Power Reports"
+    parameter.parameter19name="Periodic Power & Energy Reports"
+    parameter.parameter20name="Energy Reports"
+    parameter.parameter21name="AC Power Type"
+    parameter.parameter22name="Switch Type"
+    
+    parameter.parameter1description="This changes the speed in which the attached light dims up or down. A setting of 0 should turn the light immediately on or off (almost like an on/off switch). Increasing the value should slow down the transition speed."
+    parameter.parameter2description="This changes the speed in which the attached light dims up or down when controlled from the physical switch. A setting of 0 should turn the light immediately on or off (almost like an on/off switch). Increasing the value should slow down the transition speed. A setting of 101 should keep this in sync with parameter 1."
+    parameter.parameter3description="This changes the speed in which the attached light turns on or off. For example, when a user sends the switch a basicSet(value: 0xFF) or basicSet(value: 0x00), this is the speed in which those actions take place. A setting of 0 should turn the light immediately on or off (almost like an on/off switch). Increasing the value should slow down the transition speed. A setting of 101 should keep this in sync with parameter 1."
+    parameter.parameter4description="This changes the speed in which the attached light turns on or off from the physical switch. For example, when a user presses the up or down button, this is the speed in which those actions take place. A setting of 0 should turn the light immediately on or off (almost like an on/off switch). Increasing the value should slow down the transition speed. A setting of 101 should keep this in sync with parameter 1."
+    parameter.parameter5description="The minimum level that the dimmer allows the bulb to be dimmed to. Useful when the user has an LED bulb that does not turn on or flickers at a lower level."
+    parameter.parameter6description="The maximum level that the dimmer allows the bulb to be dimmed to. Useful when the user has an LED bulb that reaches its maximum level before the dimmer value of 99."
+    parameter.parameter7description="Inverts the orientation of the switch. Useful when the switch is installed upside down. Essentially up becomes down and down becomes up."
+    parameter.parameter8description="Automatically turns the switch off after this many seconds. When the switch is turned on a timer is started that is the duration of this setting. When the timer expires, the switch is turned off."
+    parameter.parameter9description="Default level for the dimmer when it is powered on from the local switch. A setting of 0 means that the switch will return to the level that it was on before it was turned off."
+    parameter.parameter10description="Default level for the dimmer when it is powered on from a Z-Wave command. A setting of 0 means that the switch will return to the level that it was on before it was turned off."
+    parameter.parameter11description="The state the switch should return to once power is restored after power failure. 0 = off, 1-99 = level, 100=previous."
+    parameter.parameter12description="When should the switch send commands to associated devices?\n\n01 - local\n02 - 3way\n03 - 3way & local\n04 - z-wave hub\n05 - z-wave hub & local\n06 - z-wave hub & 3-way\n07 - z-wave hub & local & 3way\n08 - timer\n09 - timer & local\n10 - timer & 3-way\n11 - timer & 3-way & local\n12 - timer & z-wave hub\n13 - timer & z-wave hub & local\n14 - timer & z-wave hub & 3-way\n15 - all"
+    parameter.parameter13description="This is the color of the LED strip."
+    parameter.parameter14description="This is the intensity of the LED strip."
+    parameter.parameter15description="This is the intensity of the LED strip when the switch is off. This is useful for users to see the light switch location when the lights are off."
+    parameter.parameter16description="LED Strip Effect"
+    parameter.parameter17description="When the LED strip is disabled (LED Strip Intensity is set to 0), this setting allows the LED strip to turn on temporarily while being adjusted."
+    parameter.parameter18description="The power level change that will result in a new power report being sent. The value is a percentage of the previous report. 0 = disabled."
+    parameter.parameter19description="Time period between consecutive power & energy reports being sent (in seconds). The timer is reset after each report is sent."
+    parameter.parameter20description="The energy level change that will result in a new energy report being sent. The value is a percentage of the previous report."
+    parameter.parameter21description="Configure the switch to use a neutral wire."
+    parameter.parameter22description="Configure the type of 3-way switch connected to the dimmer."
+    
+    return parameter."parameter${number}${value}"
+}
+
+def zwaveEvent(hubitat.zwave.commands.configurationv1.ConfigurationReport cmd) {
+    log.debug "${device.displayName} parameter '${cmd.parameterNumber}' with a byte size of '${cmd.size}' is set to '${cmd2Integer(cmd.configurationValue)}'"
+    state."parameter${cmd.parameterNumber}value" = cmd2Integer(cmd.configurationValue)
+}
+
+def cmd2Integer(array) {
+    switch(array.size()) {
+        case 1:
+            array[0]
+            break
+        case 2:
+            ((array[0] & 0xFF) << 8) | (array[1] & 0xFF)
+            break
+        case 3:
+            ((array[0] & 0xFF) << 16) | ((array[1] & 0xFF) << 8) | (array[2] & 0xFF)
+            break
+        case 4:
+            ((array[0] & 0xFF) << 24) | ((array[1] & 0xFF) << 16) | ((array[2] & 0xFF) << 8) | (array[3] & 0xFF)
+            break
+    }
+}
+
+def integer2Cmd(value, size) {
+    try{
+	switch(size) {
+	case 1:
+		[value]
+    break
+	case 2:
+    	def short value1   = value & 0xFF
+        def short value2 = (value >> 8) & 0xFF
+        [value2, value1]
+    break
+    case 3:
+    	def short value1   = value & 0xFF
+        def short value2 = (value >> 8) & 0xFF
+        def short value3 = (value >> 16) & 0xFF
+        [value3, value2, value1]
+    break
+	case 4:
+    	def short value1 = value & 0xFF
+        def short value2 = (value >> 8) & 0xFF
+        def short value3 = (value >> 16) & 0xFF
+        def short value4 = (value >> 24) & 0xFF
+		[value4, value3, value2, value1]
+	break
+	}
+    } catch (e) {
+        log.debug "Error: integer2Cmd $e Value: $value"
+    }
+}
+
+private getCommandClassVersions() {
+	[0x20: 1, 0x25: 1, 0x70: 1, 0x98: 1, 0x32: 3]
+}
+
+def zwaveEvent(hubitat.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
+    def encapsulatedCommand = cmd.encapsulatedCommand(commandClassVersions)
+    if (encapsulatedCommand) {
+        state.sec = 1
+        zwaveEvent(encapsulatedCommand)
+    }
+}
+
+def parse(description) {
+    def result = null
+    if (description.startsWith("Err 106")) {
+        state.sec = 0
+        result = createEvent(descriptionText: description, isStateChange: true)
+    } else if (description != "updated") {
+        def cmd = zwave.parse(description, commandClassVersions)
+        if (cmd) {
+            result = zwaveEvent(cmd)
+            log.debug("'$cmd' parsed to $result")
+        } else {
+            log.debug("Couldn't zwave.parse '$description'")
+        }
+    }
+    def now
+    if(location.timeZone)
+    now = new Date().format("yyyy MMM dd EEE h:mm:ss a", location.timeZone)
+    else
+    now = new Date().format("yyyy MMM dd EEE h:mm:ss a")
+    sendEvent(name: "lastActivity", value: now, displayed:false)
+    result
+}
+
+def zwaveEvent(hubitat.zwave.commands.basicv1.BasicReport cmd) {
+    // Since SmartThings isn't filtering duplicate events, we are skipping these
+    // Switch is sending SwitchMultilevelReport as well (which we will use)
+    dimmerEvents(cmd)
+}
+
+def zwaveEvent(hubitat.zwave.commands.basicv1.BasicSet cmd) {
+    dimmerEvents(cmd)
+}
+
+def zwaveEvent(hubitat.zwave.commands.switchbinaryv1.SwitchBinaryReport cmd) {
+    dimmerEvents(cmd)
+}
+
+def zwaveEvent(hubitat.zwave.commands.switchmultilevelv3.SwitchMultilevelReport cmd) {
+    dimmerEvents(cmd)
+}
+
+private dimmerEvents(hubitat.zwave.Command cmd) {
+    def value = (cmd.value ? "on" : "off")
+    def result = [createEvent(name: "switch", value: value)]
+    if (cmd.value) {
+        result << createEvent(name: "level", value: cmd.value, unit: "%")
+    }
+    return result
+}
+
+def zwaveEvent(hubitat.zwave.Command cmd) {
+    log.debug "Unhandled: $cmd"
+    null
+}
+
+def reset() {
+	def cmds = []
+    cmds << zwave.meterV2.meterReset()
+    cmds << zwave.meterV2.meterGet(scale: 0)
+    cmds << zwave.meterV2.meterGet(scale: 2)
+	commands(cmds, 1000)
+}
+
+def on() {
+    commands([
+        //zwave.basicV1.basicSet(value: 0xFF),
+        //zwave.basicV1.basicGet()
+        zwave.switchMultilevelV1.switchMultilevelSet(value: 0xFF),
+        zwave.switchMultilevelV1.switchMultilevelGet()
+    ])
+}
+
+def off() {
+    commands([
+        //zwave.basicV1.basicSet(value: 0x00),
+        //zwave.basicV1.basicGet()
+        zwave.switchMultilevelV1.switchMultilevelSet(value: 0x00),
+        zwave.switchMultilevelV1.switchMultilevelGet()
+    ])
+}
+
+def setLevel(value) {
+    if (disableRemote != "2") {
+    commands([
+        zwave.basicV1.basicSet(value: value < 100 ? value : 99),
+        zwave.basicV1.basicGet()
+    ])
+    } else {
+    commands([
+        zwave.basicV1.basicGet()
+    ])
+    }
+}
+
+def setLevel(value, duration) {
+    if (disableRemote != "2") {
+    def dimmingDuration = duration < 128 ? duration : 128 + Math.round(duration / 60)
+        commands([
+            zwave.switchMultilevelV2.switchMultilevelSet(value: value < 100 ? value : 99, dimmingDuration: dimmingDuration),
+            zwave.switchMultilevelV1.switchMultilevelGet()
+        ])
+    } else {
+    commands([
+        zwave.switchMultilevelV1.switchMultilevelGet()
+    ])
+    }
+}
+
+def ping() {
+    log.debug "ping()"
+    refresh()
+}
+
+def poll() {
+    log.debug "poll()"
+    refresh()
+}
+
+def refresh() {
+    log.debug "refresh()"
+    def cmds = []
+    cmds << zwave.switchMultilevelV1.switchMultilevelGet()
+    cmds << zwave.meterV3.meterGet(scale: 0)
+	cmds << zwave.meterV3.meterGet(scale: 2)
+    return commands(cmds)
+}
+
+private command(hubitat.zwave.Command cmd) {
+    if (state.sec) {
+        zwave.securityV1.securityMessageEncapsulation().encapsulate(cmd).format()
+    } else {
+        cmd.format()
+    }
+}
+
+private commands(commands, delay=1000) {
+    delayBetween(commands.collect{ command(it) }, delay)
+}
+
+def setDefaultAssociations() {
+    def smartThingsHubID = String.format('%02x', zwaveHubNodeId).toUpperCase()
+    state.defaultG1 = [smartThingsHubID]
+    state.defaultG2 = []
+    state.defaultG3 = []
+}
+
+def setAssociationGroup(group, node, action, endpoint = null){
+    if (! node =~ /[0-9A-F]+/)
+        return
+
+    if (group < 1 || group > maxAssociationGroup())
+        return
+    
+    def associations = state."desiredAssociation${group}"?:[]
+    switch (action) {
+        case "Remove":
+        associations = associations - node
+        break
+        case "Add":
+        associations << node
+        break
+    }
+    state."desiredAssociation${group}" = associations.unique()
+    return
+}
+
+def maxAssociationGroup(){
+   if (!state.associationGroups) {
+       if (logEnable) log.debug "Getting supported association groups from device"
+       zwave.associationV2.associationGroupingsGet() // execute the update immediately
+   }
+   (state.associationGroups?: 5) as int
+}
+
+def processAssociations(){
+   def cmds = []
+   setDefaultAssociations()
+   def associationGroups = maxAssociationGroup()
+   for (int i = 1; i <= associationGroups; i++){
+      if(state."actualAssociation${i}" != null){
+         if(state."desiredAssociation${i}" != null || state."defaultG${i}") {
+            def refreshGroup = false
+            ((state."desiredAssociation${i}"? state."desiredAssociation${i}" : [] + state."defaultG${i}") - state."actualAssociation${i}").each {
+                if (logEnable) log.debug "Adding node $it to group $i"
+                cmds << zwave.associationV2.associationSet(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
+                refreshGroup = true
+            }
+            ((state."actualAssociation${i}" - state."defaultG${i}") - state."desiredAssociation${i}").each {
+                if (logEnable) log.debug "Removing node $it from group $i"
+                cmds << zwave.associationV2.associationRemove(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
+                refreshGroup = true
+            }
+            if (refreshGroup == true) cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
+            else if (logEnable) log.debug "There are no association actions to complete for group $i"
+         }
+      } else {
+         if (logEnable) log.debug "Association info not known for group $i. Requesting info from device."
+         cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
+      }
+   }
+   return cmds
+}
+
+def zwaveEvent(hubitat.zwave.commands.associationv2.AssociationReport cmd) {
+    def temp = []
+    if (cmd.nodeId != []) {
+       cmd.nodeId.each {
+          temp += it.toString().format( '%02x', it.toInteger() ).toUpperCase()
+       }
+    } 
+    state."actualAssociation${cmd.groupingIdentifier}" = temp
+    log.debug "Associations for Group ${cmd.groupingIdentifier}: ${temp}"
+    updateDataValue("associationGroup${cmd.groupingIdentifier}", "$temp")
+}
+
+def zwaveEvent(hubitat.zwave.commands.associationv2.AssociationGroupingsReport cmd) {
+    sendEvent(name: "groups", value: cmd.supportedGroupings)
+    log.debug "Supported association groups: ${cmd.supportedGroupings}"
+    state.associationGroups = cmd.supportedGroupings
+}
+
+def zwaveEvent(hubitat.zwave.commands.versionv1.VersionReport cmd) {
+    log.debug cmd
+    if(cmd.applicationVersion != null && cmd.applicationSubVersion != null) {
+	    def firmware = "${cmd.applicationVersion}.${cmd.applicationSubVersion.toString().padLeft(2,'0')}"
+        state.needfwUpdate = "false"
+        createEvent(name: "firmware", value: "${firmware}")
+    }
+}
+
+def zwaveEvent(hubitat.zwave.commands.protectionv2.ProtectionReport cmd) {
+    log.debug cmd
+    def integerValue = cmd.localProtectionState
+    def children = childDevices
+    def childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
+    if (childDevice) {
+        childDevice.sendEvent(name: "switch", value: integerValue > 0 ? "on" : "off")        
+    }
+}

--- a/Drivers/inovelli-dimmer-nzw31-w-scene.src/inovelli-dimmer-nzw31-w-scene.groovy
+++ b/Drivers/inovelli-dimmer-nzw31-w-scene.src/inovelli-dimmer-nzw31-w-scene.groovy
@@ -1,7 +1,4 @@
  /**
- *
- *  Hubitat Import URL: https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-dimmer-nzw31-w-scene.src/inovelli-dimmer-nzw31-w-scene.groovy
- *
  *  Inovelli Dimmer NZW31/NZW31T w/Scene
  *  Author: Eric Maycock (erocm123)
  *  Date: 2018-12-04
@@ -16,6 +13,10 @@
  *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
+ *
+ *  2019-11-20: Added upgraded NZW31 fingerpint.  Fixed Association Group management.
+ *
+ *  2019-09-02: Added Hubitat's method of disabling debug messages
  *
  *  2018-12-04: Added option to "Disable Remote Control" and to send button events 1,pushed / 1,held for on / off.
  *
@@ -43,7 +44,13 @@
  */
  
 metadata {
-    definition (name: "Inovelli Dimmer NZW31 w/Scene", namespace: "InovelliUSA", author: "Eric Maycock", vid: "generic-dimmer") {
+    definition (
+        name: "Inovelli Dimmer NZW31 w/Scene", 
+        namespace: "InovelliUSA", 
+        author: "Eric Maycock", 
+        vid: "generic-dimmer",
+        importUrl: "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-dimmer-nzw31-w-scene.src/inovelli-dimmer-nzw31-w-scene.groovy"
+    ) {
         capability "Switch"
         capability "Refresh"
         capability "Polling"
@@ -72,7 +79,11 @@ metadata {
         command "holdUp"
         command "holdDown"
         
-        command "setAssociationGroup", ["number", "enum", "number", "number"] // group number, nodes, action (0 - remove, 1 - add), multi-channel endpoint (optional)
+        command "setAssociationGroup", [[name: "Group Number*",type:"NUMBER", description: "Provide the association group number to edit"], 
+                                        [name: "Z-Wave Node*", type:"STRING", description: "Enter the node number (in hex) associated with the node"], 
+                                        [name: "Action*", type:"ENUM", constraints: ["Add", "Remove"]],
+                                        [name:"Multi-channel Endpoint", type:"NUMBER", description: "Currently not implemented"]] 
+
         command "childOn"
         command "childOff"
         command "childRefresh"
@@ -82,15 +93,18 @@ metadata {
         fingerprint mfr: "051D", prod: "B111", model: "251C", deviceJoinName: "Inovelli Dimmer"
         fingerprint mfr: "015D", prod: "1F00", model: "1F00", deviceJoinName: "Inovelli Dimmer"
         fingerprint mfr: "0312", prod: "1F00", model: "1F00", deviceJoinName: "Inovelli Dimmer"
+        fingerprint mfr: "0312", prod: "1F01", model: "1F01", deviceJoinName: "Inovelli Dimmer" // Add for NZW31 upgrades to NZW31S
         fingerprint mfr: "0312", prod: "1F02", model: "1F02", deviceJoinName: "Inovelli Dimmer" // Toggle version NZW31T
         fingerprint deviceId: "0x1101", inClusters: "0x5E,0x26,0x27,0x70,0x5B,0x75,0x22,0x85,0x8E,0x59,0x55,0x86,0x72,0x5A,0x73,0x6C,0x7A"
-        
+        fingerprint deviceId: "0x1F01", inClusters: "0x5E,0x26,0x70,0x75,0x22,0x85,0x8E,0x59,0x55,0x86,0x72,0x5A,0x73,0x9F,0x6C,0x7A" // Add for NZW31 upgrades to NZW31S
+
     }
 
     simulator {
     }
     
     preferences {
+        def maxGroups
         input "minimumLevel", "number", title: "Minimum Level\n\nMinimum dimming level for attached light\nRange: 1 to 99", description: "Tap to set", required: false, range: "1..99", defaultValue: "1"
         input "dimmingStep", "number", title: "Dimming Step Size\n\nPercentage of step when switch is dimming up or down\nRange: 0 to 99 (0 - Instant)", description: "Tap to set", required: false, range: "0..99", defaultValue: "3"
         input "autoOff", "number", title: "Auto Off\n\nAutomatically turn switch off after this number of seconds\nRange: 0 to 32767", description: "Tap to set", required: false, range: "0..32767", defaultValue: "0"
@@ -127,6 +141,7 @@ metadata {
         input "pressDownX5Label", "text", title: "Label for \"Tap ▼▼▼▼▼\"", description: "Tap to set", required: false
         input "pressHoldUpLabel", "text", title: "Label for \"Hold ▲\"", description: "Tap to set", required: false
         input "pressHoldDownLabel", "text", title: "Label for \"Hold ▼\"", description: "Tap to set", required: false
+	    input name: "logEnable", type: "bool", title: "Enable debug logging", defaultValue: true
 
     }
     
@@ -253,17 +268,17 @@ def childSetLevel(String dni, value) {
 }
 
 def childOn(String dni) {
-    log.debug "childOn($dni)"
+    if (logEnable) log.debug "childOn($dni)"
     childSetLevel(dni, 99)
 }
 
 def childOff(String dni) {
-    log.debug "childOff($dni)"
+    if (logEnable) log.debug "childOff($dni)"
     childSetLevel(dni, 0)
 }
 
 def childRefresh(String dni) {
-    log.debug "childRefresh($dni)"
+    if (logEnable) log.debug "childRefresh($dni)"
 }
 
 def childExists(ep) {
@@ -276,24 +291,24 @@ def childExists(ep) {
 }
 
 def installed() {
-    log.debug "installed()"
+    if (logEnable) log.debug "installed()"
     refresh()
 }
 
 def configure() {
-    log.debug "configure()"
+    if (logEnable) log.debug "configure()"
     def cmds = initialize()
     commands(cmds)
 }
 
 def updated() {
     if (!state.lastRan || now() >= state.lastRan + 2000) {
-        log.debug "updated()"
+        if (logEnable) log.debug "updated()"
         state.lastRan = now()
         def cmds = initialize()
         commands(cmds)
     } else {
-        log.debug "updated() ran within the last 2 seconds. Skipping execution."
+        if (logEnable) log.debug "updated() ran within the last 2 seconds. Skipping execution."
     }
 }
 
@@ -323,7 +338,7 @@ def integer2Cmd(value, size) {
 	break
 	}
     } catch (e) {
-        log.debug "Error: integer2Cmd $e Value: $value"
+        if (logEnable) log.debug "Error: integer2Cmd $e Value: $value"
     }
 }
 
@@ -340,11 +355,11 @@ def initialize() {
         runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
     }
     } else if (!enableDefaultLocalChild && childExists("ep8")) {
-        log.debug "Trying to delete child device ep8. If this fails it is likely that there is a SmartApp using the child device in question."
+        if (logEnable) log.debug "Trying to delete child device ep8. If this fails it is likely that there is a SmartApp using the child device in question."
         def children = childDevices
         def childDevice = children.find{it.deviceNetworkId.endsWith("ep8")}
         try {
-            log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            if (logEnable) log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
             //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
         } catch (e) {
             runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
@@ -359,11 +374,11 @@ def initialize() {
         runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
     }
     } else if (!enableDefaultLocalChild && childExists("ep9")) {
-        log.debug "Trying to delete child device ep9. If this fails it is likely that there is a SmartApp using the child device in question."
+        if (logEnable) log.debug "Trying to delete child device ep9. If this fails it is likely that there is a SmartApp using the child device in question."
         def children = childDevices
         def childDevice = children.find{it.deviceNetworkId.endsWith("ep9")}
         try {
-            log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            if (logEnable) log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
             //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
         } catch (e) {
             runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
@@ -378,11 +393,11 @@ def initialize() {
         runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
     }
     } else if (!enableDisableLocalChild && childExists("ep101")) {
-        log.debug "Trying to delete child device ep101. If this fails it is likely that there is a SmartApp using the child device in question."
+        if (logEnable) log.debug "Trying to delete child device ep101. If this fails it is likely that there is a SmartApp using the child device in question."
         def children = childDevices
         def childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
         try {
-            log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            if (logEnable) log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
             //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
         } catch (e) {
             runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
@@ -427,7 +442,7 @@ def initialize() {
     cmds << zwave.configurationV1.configurationGet(parameterNumber: 4)
     cmds << zwave.configurationV1.configurationSet(configurationValue: autoOff!=null? integer2Cmd(autoOff.toInteger(), 2) : integer2Cmd(0,2), parameterNumber: 5, size: 2)
     cmds << zwave.configurationV1.configurationGet(parameterNumber: 5)
-	log.debug "setting parameter 5 to ${autoOff!=null? autoOff.toInteger() : 0}"
+	if (logEnable) log.debug "setting parameter 5 to ${autoOff!=null? autoOff.toInteger() : 0}"
     if (state.defaultLocal != settings.defaultLocal) {
         cmds << zwave.configurationV1.configurationSet(scaledConfigurationValue: defaultLocal!=null? defaultLocal.toInteger() : 0, parameterNumber: 8, size: 1)
         cmds << zwave.configurationV1.configurationGet(parameterNumber: 8)
@@ -460,7 +475,7 @@ def initialize() {
 }
 
 def zwaveEvent(hubitat.zwave.commands.configurationv1.ConfigurationReport cmd) {
-    log.debug "${device.displayName} parameter '${cmd.parameterNumber}' with a byte size of '${cmd.size}' is set to '${cmd2Integer(cmd.configurationValue)}'"
+    if (logEnable) log.debug "${device.displayName} parameter '${cmd.parameterNumber}' with a byte size of '${cmd.size}' is set to '${cmd2Integer(cmd.configurationValue)}'"
     def integerValue = cmd2Integer(cmd.configurationValue)
     switch (cmd.parameterNumber) {
         case 8:
@@ -508,9 +523,9 @@ def parse(description) {
         def cmd = zwave.parse(description, [0x20: 1, 0x25: 1, 0x70: 1, 0x98: 1])
         if (cmd) {
             result = zwaveEvent(cmd)
-            log.debug("'$description' parsed to $result")
+            if (logEnable) log.debug("'$description' parsed to $result")
         } else {
-            log.debug("Couldn't zwave.parse '$description'")
+            if (logEnable) log.debug("Couldn't zwave.parse '$description'")
         }
     }
     def now
@@ -583,7 +598,7 @@ def buttonEvent(button, value, type = "digital") {
 }
 
 def zwaveEvent(hubitat.zwave.Command cmd) {
-    log.debug "Unhandled: $cmd"
+    if (logEnable) log.debug "Unhandled: $cmd"
     null
 }
 
@@ -647,17 +662,17 @@ def setLevel(value, duration) {
 }
 
 def ping() {
-    log.debug "ping()"
+    if (logEnable) log.debug "ping()"
     refresh()
 }
 
 def poll() {
-    log.debug "poll()"
+    if (logEnable) log.debug "poll()"
     refresh()
 }
 
 def refresh() {
-    log.debug "refresh()"
+    if (logEnable) log.debug "refresh()"
     commands([zwave.switchBinaryV1.switchBinaryGet(),
               zwave.switchMultilevelV1.switchMultilevelGet()
     ])
@@ -724,56 +739,63 @@ def holdDown() {
 }
 
 def setDefaultAssociations() {
-    def smartThingsHubID = (zwaveHubNodeId.toString().format( '%02x', zwaveHubNodeId )).toUpperCase()
+    def smartThingsHubID = String.format('%02x', zwaveHubNodeId).toUpperCase()
     state.defaultG1 = [smartThingsHubID]
     state.defaultG2 = []
     state.defaultG3 = []
 }
 
-def setAssociationGroup(group, nodes, action, endpoint = null){
-    if (!state."desiredAssociation${group}") {
-        state."desiredAssociation${group}" = nodes
-    } else {
-        switch (action) {
-            case 0:
-                state."desiredAssociation${group}" = state."desiredAssociation${group}" - nodes
-            break
-            case 1:
-                state."desiredAssociation${group}" = state."desiredAssociation${group}" + nodes
-            break
-        }
+def setAssociationGroup(group, node, action, endpoint = null){
+    if (! node =~ /[0-9A-F]+/)
+        return
+
+    if (group < 1 || group > maxAssociationGroup())
+        return
+    
+    def associations = state."desiredAssociation${group}"?:[]
+    switch (action) {
+        case "Remove":
+        associations = associations - node
+        break
+        case "Add":
+        associations << node
+        break
     }
+    state."desiredAssociation${group}" = associations.unique()
+    return
+}
+
+def maxAssociationGroup(){
+   if (!state.associationGroups) {
+       if (logEnable) log.debug "Getting supported association groups from device"
+       zwave.associationV2.associationGroupingsGet() // execute the update immediately
+   }
+   (state.associationGroups?: 5) as int
 }
 
 def processAssociations(){
    def cmds = []
    setDefaultAssociations()
-   def associationGroups = 5
-   if (state.associationGroups) {
-       associationGroups = state.associationGroups
-   } else {
-       log.debug "Getting supported association groups from device"
-       cmds <<  zwave.associationV2.associationGroupingsGet()
-   }
+   def associationGroups = maxAssociationGroup()
    for (int i = 1; i <= associationGroups; i++){
       if(state."actualAssociation${i}" != null){
          if(state."desiredAssociation${i}" != null || state."defaultG${i}") {
             def refreshGroup = false
             ((state."desiredAssociation${i}"? state."desiredAssociation${i}" : [] + state."defaultG${i}") - state."actualAssociation${i}").each {
-                log.debug "Adding node $it to group $i"
-                cmds << zwave.associationV2.associationSet(groupingIdentifier:i, nodeId:Integer.parseInt(it,16))
+                if (logEnable) log.debug "Adding node $it to group $i"
+                cmds << zwave.associationV2.associationSet(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
                 refreshGroup = true
             }
             ((state."actualAssociation${i}" - state."defaultG${i}") - state."desiredAssociation${i}").each {
-                log.debug "Removing node $it from group $i"
-                cmds << zwave.associationV2.associationRemove(groupingIdentifier:i, nodeId:Integer.parseInt(it,16))
+                if (logEnable) log.debug "Removing node $it from group $i"
+                cmds << zwave.associationV2.associationRemove(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
                 refreshGroup = true
             }
             if (refreshGroup == true) cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
-            else log.debug "There are no association actions to complete for group $i"
+            else if (logEnable) log.debug "There are no association actions to complete for group $i"
          }
       } else {
-         log.debug "Association info not known for group $i. Requesting info from device."
+         if (logEnable) log.debug "Association info not known for group $i. Requesting info from device."
          cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
       }
    }
@@ -788,18 +810,18 @@ def zwaveEvent(hubitat.zwave.commands.associationv2.AssociationReport cmd) {
        }
     } 
     state."actualAssociation${cmd.groupingIdentifier}" = temp
-    log.debug "Associations for Group ${cmd.groupingIdentifier}: ${temp}"
+    if (logEnable) log.debug "Associations for Group ${cmd.groupingIdentifier}: ${temp}"
     updateDataValue("associationGroup${cmd.groupingIdentifier}", "$temp")
 }
 
 def zwaveEvent(hubitat.zwave.commands.associationv2.AssociationGroupingsReport cmd) {
     sendEvent(name: "groups", value: cmd.supportedGroupings)
-    log.debug "Supported association groups: ${cmd.supportedGroupings}"
+    if (logEnable) log.debug "Supported association groups: ${cmd.supportedGroupings}"
     state.associationGroups = cmd.supportedGroupings
 }
 
 def zwaveEvent(hubitat.zwave.commands.versionv1.VersionReport cmd) {
-    log.debug cmd
+    if (logEnable) log.debug cmd
     if(cmd.applicationVersion && cmd.applicationSubVersion) {
 	    def firmware = "${cmd.applicationVersion}.${cmd.applicationSubVersion.toString().padLeft(2,'0')}"
         state.needfwUpdate = "false"
@@ -808,7 +830,7 @@ def zwaveEvent(hubitat.zwave.commands.versionv1.VersionReport cmd) {
 }
 
 def zwaveEvent(hubitat.zwave.commands.protectionv2.ProtectionReport cmd) {
-    log.debug cmd
+    if (logEnable) log.debug cmd
     def integerValue = cmd.localProtectionState
     def children = childDevices
     def childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
@@ -816,3 +838,6 @@ def zwaveEvent(hubitat.zwave.commands.protectionv2.ProtectionReport cmd) {
         childDevice.sendEvent(name: "switch", value: integerValue > 0 ? "on" : "off")        
     }
 }
+
+
+

--- a/Drivers/inovelli-dimmer-nzw31-w-scene.src/inovelli-dimmer-nzw31-w-scene.groovy
+++ b/Drivers/inovelli-dimmer-nzw31-w-scene.src/inovelli-dimmer-nzw31-w-scene.groovy
@@ -745,21 +745,35 @@ def setDefaultAssociations() {
     state.defaultG3 = []
 }
 
-def setAssociationGroup(group, node, action, endpoint = null){
-    if (! node =~ /[0-9A-F]+/)
-        return
+def setAssociationGroup(group, nodes, action, endpoint = null){
+    // Normalize the arguments to be backwards compatible with the old method
+    action = "${action}" == "1" ? "Add" : "${action}" == "0" ? "Remove" : "${action}" // convert 1/0 to Add/Remove
+    group  = "${group}" =~ /\d+/ ? (group as int) : group                             // convert group to int (if possible)
+    nodes  = [] + nodes ?: [nodes]                                                    // convert to collection if not already a collection
 
-    if (group < 1 || group > maxAssociationGroup())
+    if (! nodes.every { it =~ /[0-9A-F]+/ }) {
+        log.error "invalid Nodes ${nodes}"
         return
+    }
+
+    if (group < 1 || group > maxAssociationGroup()) {
+        log.error "Association group is invalid 1 <= ${group} <= ${maxAssociationGroup()}"
+        return
+    }
     
     def associations = state."desiredAssociation${group}"?:[]
-    switch (action) {
-        case "Remove":
-        associations = associations - node
-        break
-        case "Add":
-        associations << node
-        break
+    nodes.each { 
+        node = "${it}"
+        switch (action) {
+            case "Remove":
+            if (logEnable) log.debug "Removing node ${node} from association group ${group}"
+            associations = associations - node
+            break
+            case "Add":
+            if (logEnable) log.debug "Adding node ${node} to association group ${group}"
+            associations << node
+            break
+        }
     }
     state."desiredAssociation${group}" = associations.unique()
     return

--- a/Drivers/inovelli-dimmer-nzw31.src/inovelli-dimmer-nzw31.groovy
+++ b/Drivers/inovelli-dimmer-nzw31.src/inovelli-dimmer-nzw31.groovy
@@ -557,21 +557,35 @@ def setDefaultAssociations() {
     state.defaultG3 = []
 }
 
-def setAssociationGroup(group, node, action, endpoint = null){
-    if (! node =~ /[0-9A-F]+/)
-        return
+def setAssociationGroup(group, nodes, action, endpoint = null){
+    // Normalize the arguments to be backwards compatible with the old method
+    action = "${action}" == "1" ? "Add" : "${action}" == "0" ? "Remove" : "${action}" // convert 1/0 to Add/Remove
+    group  = "${group}" =~ /\d+/ ? (group as int) : group                             // convert group to int (if possible)
+    nodes  = [] + nodes ?: [nodes]                                                    // convert to collection if not already a collection
 
-    if (group < 1 || group > maxAssociationGroup())
+    if (! nodes.every { it =~ /[0-9A-F]+/ }) {
+        log.error "invalid Nodes ${nodes}"
         return
+    }
+
+    if (group < 1 || group > maxAssociationGroup()) {
+        log.error "Association group is invalid 1 <= ${group} <= ${maxAssociationGroup()}"
+        return
+    }
     
     def associations = state."desiredAssociation${group}"?:[]
-    switch (action) {
-        case "Remove":
-        associations = associations - node
-        break
-        case "Add":
-        associations << node
-        break
+    nodes.each { 
+        node = "${it}"
+        switch (action) {
+            case "Remove":
+            if (logEnable) log.debug "Removing node ${node} from association group ${group}"
+            associations = associations - node
+            break
+            case "Add":
+            if (logEnable) log.debug "Adding node ${node} to association group ${group}"
+            associations << node
+            break
+        }
     }
     state."desiredAssociation${group}" = associations.unique()
     return

--- a/Drivers/inovelli-dimmer-nzw31.src/inovelli-dimmer-nzw31.groovy
+++ b/Drivers/inovelli-dimmer-nzw31.src/inovelli-dimmer-nzw31.groovy
@@ -1,7 +1,4 @@
 /**
- *
- *  Hubitat Import URL: https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-dimmer-nzw31.src/inovelli-dimmer-nzw31.groovy
- *
  *  Inovelli Dimmer NZW31
  *  Author: Eric Maycock (erocm123)
  *  Date: 2018-12-04
@@ -16,6 +13,11 @@
  *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
+ *
+ *  2019-11-20: Fixed Association Group management.
+ *              Added upgraded NZW31 fingerpint.
+ *
+ *  2019-09-02: Added Hubitat's method of disabling debug messages
  *
  *  2018-12-04: Added option to "Disable Remote Control" and to send button events 1,pushed / 1,held for on / off.
  *
@@ -41,7 +43,13 @@
  */
  
 metadata {
-    definition (name: "Inovelli Dimmer NZW31", namespace: "InovelliUSA", author: "Eric Maycock", vid: "generic-dimmer") {
+    definition (
+        name: "Inovelli Dimmer NZW31", 
+        namespace: "InovelliUSA", 
+        author: "Eric Maycock", 
+        vid: "generic-dimmer",
+        importUrl: "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-dimmer-nzw31.src/inovelli-dimmer-nzw31.groovy"
+    ) {
         capability "Switch"
         capability "Refresh"
         capability "Polling"
@@ -55,7 +63,11 @@ metadata {
         attribute "lastEvent", "String"
         attribute "firmware", "String"
         
-        command "setAssociationGroup", ["number", "enum", "number", "number"] // group number, nodes, action (0 - remove, 1 - add), multi-channel endpoint (optional)
+        command "setAssociationGroup", [[name: "Group Number*",type:"NUMBER", description: "Provide the association group number to edit"], 
+                                        [name: "Z-Wave Node*", type:"STRING", description: "Enter the node number (in hex) associated with the node"], 
+                                        [name: "Action*", type:"ENUM", constraints: ["Add", "Remove"]],
+                                        [name:"Multi-channel Endpoint", type:"NUMBER", description: "Currently not implemented"]] 
+
         command "childOn"
         command "childOff"
         command "childRefresh"
@@ -66,6 +78,7 @@ metadata {
         fingerprint mfr: "015D", prod: "1F01", model: "1F01", deviceJoinName: "Inovelli Dimmer"
         fingerprint mfr: "0312", prod: "1F01", model: "1F01", deviceJoinName: "Inovelli Dimmer"
         fingerprint deviceId: "0x1101", inClusters: "0x5E,0x26,0x27,0x70,0x75,0x22,0x85,0x8E,0x59,0x55,0x86,0x72,0x5A,0x73,0x6C,0x7A"
+        fingerprint deviceId: "0x1F01", inClusters: "0x5E,0x26,0x70,0x75,0x22,0x85,0x8E,0x59,0x55,0x86,0x72,0x5A,0x73,0x9F,0x6C,0x7A" // Add for NZW31 upgrades to NZW31S
     }
 
     simulator {
@@ -94,6 +107,7 @@ metadata {
         input "group3remote", "bool", title: "Send command on z-wave action", description: "", required: false, defaultValue: true
         input "group3way", "bool", title: "Send command on 3-way action", description: "", required: false, defaultValue: true
         input "group3timer", "bool", title: "Send command on auto off timer", description: "", required: false, defaultValue: true
+	input name: "logEnable", type: "bool", title: "Enable debug logging", defaultValue: true
     }
     
     tiles {
@@ -129,24 +143,24 @@ metadata {
 }
 
 def installed() {
-    log.debug "installed()"
+    if (logEnable) log.debug "installed()"
     refresh()
 }
 
 def configure() {
-    log.debug "configure()"
+    if (logEnable) log.debug "configure()"
     def cmds = initialize()
     commands(cmds)
 }
 
 def updated() {
     if (!state.lastRan || now() >= state.lastRan + 2000) {
-        log.debug "updated()"
+        if (logEnable) log.debug "updated()"
         state.lastRan = now()
         def cmds = initialize()
         commands(cmds)
     } else {
-        log.debug "updated() ran within the last 2 seconds. Skipping execution."
+        if (logEnable) log.debug "updated() ran within the last 2 seconds. Skipping execution."
     }
 }
 
@@ -176,7 +190,7 @@ def integer2Cmd(value, size) {
 	break
 	}
     } catch (e) {
-        log.debug "Error: integer2Cmd $e Value: $value"
+        if (logEnable) log.debug "Error: integer2Cmd $e Value: $value"
     }
 }
 
@@ -191,11 +205,11 @@ def initialize() {
         runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
     }
     } else if (!enableDefaultLocalChild && childExists("ep8")) {
-        log.debug "Trying to delete child device ep8. If this fails it is likely that there is a SmartApp using the child device in question."
+        if (logEnable) log.debug "Trying to delete child device ep8. If this fails it is likely that there is a SmartApp using the child device in question."
         def children = childDevices
         def childDevice = children.find{it.deviceNetworkId.endsWith("ep8")}
         try {
-            log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            if (logEnable) log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
             //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
         } catch (e) {
             runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
@@ -210,11 +224,11 @@ def initialize() {
         runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
     }
     } else if (!enableDefaultLocalChild && childExists("ep9")) {
-        log.debug "Trying to delete child device ep9. If this fails it is likely that there is a SmartApp using the child device in question."
+        if (logEnable) log.debug "Trying to delete child device ep9. If this fails it is likely that there is a SmartApp using the child device in question."
         def children = childDevices
         def childDevice = children.find{it.deviceNetworkId.endsWith("ep9")}
         try {
-            log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            if (logEnable) log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
             //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
         } catch (e) {
             runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
@@ -229,11 +243,11 @@ def initialize() {
         runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
     }
     } else if (!enableDisableLocalChild && childExists("ep101")) {
-        log.debug "Trying to delete child device ep101. If this fails it is likely that there is a SmartApp using the child device in question."
+        if (logEnable) log.debug "Trying to delete child device ep101. If this fails it is likely that there is a SmartApp using the child device in question."
         def children = childDevices
         def childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
         try {
-            log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            if (logEnable) log.debug "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
             //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
         } catch (e) {
             runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
@@ -305,9 +319,9 @@ def parse(description) {
         def cmd = zwave.parse(description, [0x20: 1, 0x25: 1, 0x70: 1, 0x98: 1])
         if (cmd) {
             result = zwaveEvent(cmd)
-            log.debug("'$description' parsed to $result")
+            if (logEnable) log.debug("'$description' parsed to $result")
         } else {
-            log.debug("Couldn't zwave.parse '$description'")
+            if (logEnable) log.debug("Couldn't zwave.parse '$description'")
         }
     }
     def now
@@ -347,7 +361,7 @@ private dimmerEvents(hubitat.zwave.Command cmd) {
 }
 
 def zwaveEvent(hubitat.zwave.commands.configurationv1.ConfigurationReport cmd) {
-    log.debug "${device.displayName} parameter '${cmd.parameterNumber}' with a byte size of '${cmd.size}' is set to '${cmd2Integer(cmd.configurationValue)}'"
+    if (logEnable) log.debug "${device.displayName} parameter '${cmd.parameterNumber}' with a byte size of '${cmd.size}' is set to '${cmd2Integer(cmd.configurationValue)}'"
     def integerValue = cmd2Integer(cmd.configurationValue)
     switch (cmd.parameterNumber) {
         case 8:
@@ -378,7 +392,7 @@ def zwaveEvent(hubitat.zwave.commands.securityv1.SecurityMessageEncapsulation cm
 }
 
 def zwaveEvent(hubitat.zwave.Command cmd) {
-    log.debug "Unhandled: $cmd"
+    if (logEnable) log.debug "Unhandled: $cmd"
     null
 }
 
@@ -443,17 +457,17 @@ def setLevel(value, duration) {
 
 
 def childOn(String dni) {
-    log.debug "childOn($dni)"
+    if (logEnable) log.debug "childOn($dni)"
     childSetLevel(dni, 99)
 }
 
 def childOff(String dni) {
-    log.debug "childOff($dni)"
+    if (logEnable) log.debug "childOff($dni)"
     childSetLevel(dni, 0)
 }
 
 def childRefresh(String dni) {
-    log.debug "childRefresh($dni)"
+    if (logEnable) log.debug "childRefresh($dni)"
 }
 
 def childSetLevel(String dni, value) {
@@ -508,17 +522,17 @@ def childExists(ep) {
 }
 
 def ping() {
-    log.debug "ping()"
+    if (logEnable) log.debug "ping()"
     refresh()
 }
 
 def poll() {
-    log.debug "poll()"
+    if (logEnable) log.debug "poll()"
     refresh()
 }
 
 def refresh() {
-    log.debug "refresh()"
+    if (logEnable) log.debug "refresh()"
     commands([zwave.switchBinaryV1.switchBinaryGet(),
               zwave.switchMultilevelV1.switchMultilevelGet()
     ])
@@ -537,56 +551,63 @@ private commands(commands, delay=500) {
 }
 
 def setDefaultAssociations() {
-    def smartThingsHubID = (zwaveHubNodeId.toString().format( '%02x', zwaveHubNodeId )).toUpperCase()
+    def smartThingsHubID = String.format('%02x', zwaveHubNodeId).toUpperCase()
     state.defaultG1 = [smartThingsHubID]
     state.defaultG2 = []
     state.defaultG3 = []
 }
 
-def setAssociationGroup(group, nodes, action, endpoint = null){
-    if (!state."desiredAssociation${group}") {
-        state."desiredAssociation${group}" = nodes
-    } else {
-        switch (action) {
-            case 0:
-                state."desiredAssociation${group}" = state."desiredAssociation${group}" - nodes
-            break
-            case 1:
-                state."desiredAssociation${group}" = state."desiredAssociation${group}" + nodes
-            break
-        }
+def setAssociationGroup(group, node, action, endpoint = null){
+    if (! node =~ /[0-9A-F]+/)
+        return
+
+    if (group < 1 || group > maxAssociationGroup())
+        return
+    
+    def associations = state."desiredAssociation${group}"?:[]
+    switch (action) {
+        case "Remove":
+        associations = associations - node
+        break
+        case "Add":
+        associations << node
+        break
     }
+    state."desiredAssociation${group}" = associations.unique()
+    return
+}
+
+def maxAssociationGroup(){
+   if (!state.associationGroups) {
+       if (logEnable) log.debug "Getting supported association groups from device"
+       zwave.associationV2.associationGroupingsGet() // execute the update immediately
+   }
+   (state.associationGroups?: 5) as int
 }
 
 def processAssociations(){
    def cmds = []
    setDefaultAssociations()
-   def associationGroups = 5
-   if (state.associationGroups) {
-       associationGroups = state.associationGroups
-   } else {
-       log.debug "Getting supported association groups from device"
-       cmds <<  zwave.associationV2.associationGroupingsGet()
-   }
+   def associationGroups = maxAssociationGroup()
    for (int i = 1; i <= associationGroups; i++){
       if(state."actualAssociation${i}" != null){
          if(state."desiredAssociation${i}" != null || state."defaultG${i}") {
             def refreshGroup = false
             ((state."desiredAssociation${i}"? state."desiredAssociation${i}" : [] + state."defaultG${i}") - state."actualAssociation${i}").each {
-                log.debug "Adding node $it to group $i"
-                cmds << zwave.associationV2.associationSet(groupingIdentifier:i, nodeId:Integer.parseInt(it,16))
+                if (logEnable) log.debug "Adding node $it to group $i"
+                cmds << zwave.associationV2.associationSet(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
                 refreshGroup = true
             }
             ((state."actualAssociation${i}" - state."defaultG${i}") - state."desiredAssociation${i}").each {
-                log.debug "Removing node $it from group $i"
-                cmds << zwave.associationV2.associationRemove(groupingIdentifier:i, nodeId:Integer.parseInt(it,16))
+                if (logEnable) log.debug "Removing node $it from group $i"
+                cmds << zwave.associationV2.associationRemove(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
                 refreshGroup = true
             }
             if (refreshGroup == true) cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
-            else log.debug "There are no association actions to complete for group $i"
+            else if (logEnable) log.debug "There are no association actions to complete for group $i"
          }
       } else {
-         log.debug "Association info not known for group $i. Requesting info from device."
+         if (logEnable) log.debug "Association info not known for group $i. Requesting info from device."
          cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
       }
    }
@@ -601,18 +622,18 @@ def zwaveEvent(hubitat.zwave.commands.associationv2.AssociationReport cmd) {
        }
     } 
     state."actualAssociation${cmd.groupingIdentifier}" = temp
-    log.debug "Associations for Group ${cmd.groupingIdentifier}: ${temp}"
+    if (logEnable) log.debug "Associations for Group ${cmd.groupingIdentifier}: ${temp}"
     updateDataValue("associationGroup${cmd.groupingIdentifier}", "$temp")
 }
 
 def zwaveEvent(hubitat.zwave.commands.associationv2.AssociationGroupingsReport cmd) {
     sendEvent(name: "groups", value: cmd.supportedGroupings)
-    log.debug "Supported association groups: ${cmd.supportedGroupings}"
+    if (logEnable) log.debug "Supported association groups: ${cmd.supportedGroupings}"
     state.associationGroups = cmd.supportedGroupings
 }
 
 def zwaveEvent(hubitat.zwave.commands.versionv1.VersionReport cmd) {
-    log.debug cmd
+    if (logEnable) log.debug cmd
     if(cmd.applicationVersion && cmd.applicationSubVersion) {
 	    def firmware = "${cmd.applicationVersion}.${cmd.applicationSubVersion.toString().padLeft(2,'0')}"
         state.needfwUpdate = "false"
@@ -621,7 +642,7 @@ def zwaveEvent(hubitat.zwave.commands.versionv1.VersionReport cmd) {
 }
 
 def zwaveEvent(hubitat.zwave.commands.protectionv2.ProtectionReport cmd) {
-    log.debug cmd
+    if (logEnable) log.debug cmd
     def integerValue = cmd.localProtectionState
     def children = childDevices
     def childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}

--- a/Drivers/inovelli-dimmer-red-series-lzw31-sn.src/inovelli-dimmer-red-series-lzw31-sn.groovy
+++ b/Drivers/inovelli-dimmer-red-series-lzw31-sn.src/inovelli-dimmer-red-series-lzw31-sn.groovy
@@ -961,21 +961,35 @@ def setDefaultAssociations() {
     state.defaultG3 = []
 }
 
-def setAssociationGroup(group, node, action, endpoint = null){
-    if (! node =~ /[0-9A-F]+/)
-        return
+def setAssociationGroup(group, nodes, action, endpoint = null){
+    // Normalize the arguments to be backwards compatible with the old method
+    action = "${action}" == "1" ? "Add" : "${action}" == "0" ? "Remove" : "${action}" // convert 1/0 to Add/Remove
+    group  = "${group}" =~ /\d+/ ? (group as int) : group                             // convert group to int (if possible)
+    nodes  = [] + nodes ?: [nodes]                                                    // convert to collection if not already a collection
 
-    if (group < 1 || group > maxAssociationGroup())
+    if (! nodes.every { it =~ /[0-9A-F]+/ }) {
+        log.error "invalid Nodes ${nodes}"
         return
+    }
+
+    if (group < 1 || group > maxAssociationGroup()) {
+        log.error "Association group is invalid 1 <= ${group} <= ${maxAssociationGroup()}"
+        return
+    }
     
     def associations = state."desiredAssociation${group}"?:[]
-    switch (action) {
-        case "Remove":
-        associations = associations - node
-        break
-        case "Add":
-        associations << node
-        break
+    nodes.each { 
+        node = "${it}"
+        switch (action) {
+            case "Remove":
+            if (logEnable) log.debug "Removing node ${node} from association group ${group}"
+            associations = associations - node
+            break
+            case "Add":
+            if (logEnable) log.debug "Adding node ${node} to association group ${group}"
+            associations << node
+            break
+        }
     }
     state."desiredAssociation${group}" = associations.unique()
     return

--- a/Drivers/inovelli-dimmer-red-series-lzw31-sn.src/inovelli-dimmer-red-series-lzw31-sn.groovy
+++ b/Drivers/inovelli-dimmer-red-series-lzw31-sn.src/inovelli-dimmer-red-series-lzw31-sn.groovy
@@ -1,0 +1,1071 @@
+/**
+ *  Inovelli Dimmer Red Series LZW31-SN
+ *  Author: Eric Maycock (erocm123)
+ *  Date: 2019-11-16
+ *
+ *  Copyright 2019 Eric Maycock / Inovelli
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ *  2019-11-20: Fixed Association Group management.
+ *
+ *  2019-11-16: Ability to choose custom LED bar color. Child devices to control default level (local & z-wave),
+ *              local & remote protection. Ability to turn on / off info & debug logging. Additional logging added.
+ *              Prevent overwriting parameters that are configured at the switch. Bumping number of notifications to 5.
+ *              Added additional button events for "released" vs "held". Button 8 pushed (up released)
+ *              & button 8 released (down released). Other bug fixes and improvements. 
+ *
+ *  2019-11-13: Bug fix for not being able to set default level back to 0
+ */
+ 
+metadata {
+    definition (name: "Inovelli Dimmer Red Series LZW31-SN", namespace: "InovelliUSA", author: "Eric Maycock", vid: "generic-dimmer", importUrl:"https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-dimmer-red-series-lzw31-sn.src/inovelli-dimmer-red-series-lzw31-sn.groovy") {
+        capability "Switch"
+        capability "Refresh"
+        capability "Polling"
+        capability "Actuator"
+        capability "Sensor"
+        //capability "Health Check"
+        capability "PushableButton"
+        capability "HoldableButton"
+        capability "Switch Level"
+        capability "Configuration"
+        capability "Energy Meter"
+        capability "Power Meter"
+        
+        attribute "lastActivity", "String"
+        attribute "lastEvent", "String"
+        attribute "firmware", "String"
+        
+        command "pressUpX1"
+        command "pressDownX1"
+        command "pressUpX2"
+        command "pressDownX2"
+        command "pressUpX3"
+        command "pressDownX3"
+        command "pressUpX4"
+        command "pressDownX4"
+        command "pressUpX5"
+        command "pressDownX5"
+        command "holdUp"
+        command "holdDown"
+        
+        command "childOn"
+        command "childOff"
+        command "childSetLevel"
+        command "childRefresh"
+        command "reset"
+        
+        command "setAssociationGroup", [[name: "Group Number*",type:"NUMBER", description: "Provide the association group number to edit"], 
+                                        [name: "Z-Wave Node*", type:"STRING", description: "Enter the node number (in hex) associated with the node"], 
+                                        [name: "Action*", type:"ENUM", constraints: ["Add", "Remove"]],
+                                        [name:"Multi-channel Endpoint", type:"NUMBER", description: "Currently not implemented"]] 
+
+        fingerprint mfr: "031E", prod: "0001", model: "0001", deviceJoinName: "Inovelli Dimmer Red Series"
+        fingerprint deviceId: "0x1101", inClusters: "0x5E,0x55,0x98,0x9F,0x6C,0x22,0x26,0x70,0x85,0x59,0x86,0x32,0x72,0x5A,0x5B,0x73,0x75,0x7A" // Red Series
+        fingerprint deviceId: "0x1101", inClusters: "0x5E,0x26,0x70,0x85,0x59,0x55,0x86,0x72,0x5A,0x73,0x32,0x98,0x9F,0x5B,0x6C,0x75,0x22,0x7A" // Red Series
+    }
+
+    simulator {
+    }
+    
+    preferences {
+        generate_preferences()
+    }
+
+}
+
+def generate_preferences()
+{
+    getParameterNumbers().each { i ->
+        
+        switch(getParameterInfo(i, "type"))
+        {   
+            case "number":
+                input "parameter${i}", "number",
+                    title:getParameterInfo(i, "name") + "\n" + getParameterInfo(i, "description") + "\nRange: " + getParameterInfo(i, "options") + "\nDefault: " + getParameterInfo(i, "default"),
+                    range: getParameterInfo(i, "options")
+                    //defaultValue: getParameterInfo(i, "default")
+                    //displayDuringSetup: "${it.@displayDuringSetup}"
+            break
+            case "enum":
+                input "parameter${i}", "enum",
+                    title:getParameterInfo(i, "name"), // + getParameterInfo(i, "description"),
+                    //defaultValue: getParameterInfo(i, "default"),
+                    //displayDuringSetup: "${it.@displayDuringSetup}",
+                    options: getParameterInfo(i, "options")
+            break
+        }  
+        if (i == 13){
+            input "parameter13custom", "number", 
+                title: "Custom LED RGB Value", 
+                description: "\nInput a custom value in this field to override the above setting. The value should be between 0 - 360 and can be determined by using the typical hue color wheel.", 
+                required: false,
+                range: "0..360"
+        }
+    }
+    
+    input description: "When each notification set (Color, Level, Duration, Type) is configured, a switch child device is created that can be used in SmartApps to activate that notification.", title: "LED Notifications", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+    
+    [1,2,3,4,5].each { i ->
+                input "parameter16-${i}a", "enum", title: "LED Effect Color - Notification $i", description: "Tap to set", displayDuringSetup: false, required: false, options: [
+                    0:"Red",
+                    21:"Orange",
+                    42:"Yellow",
+                    85:"Green",
+                    127:"Cyan",
+                    170:"Blue",
+                    212:"Violet",
+                    234:"Pink"]
+                input "parameter16-${i}b", "enum", title: "LED Effect Level - Notification $i", description: "Tap to set", displayDuringSetup: false, required: false, options: [
+                    0:"0%",
+                    1:"10%",
+                    2:"20%",
+                    3:"30%",
+                    4:"40%",
+                    5:"50%",
+                    6:"60%",
+                    7:"70%",
+                    8:"80%",
+                    9:"90%",
+                    10:"100%"]
+                input "parameter16-${i}c", "enum", title: "LED Effect Duration - Notification $i", description: "Tap to set", displayDuringSetup: false, required: false, options: [
+                    1:"1 Second",
+                    2:"2 Seconds",
+                    3:"3 Seconds",
+                    4:"4 Seconds",
+                    5:"5 Seconds",
+                    6:"6 Seconds",
+                    7:"7 Seconds",
+                    8:"8 Seconds",
+                    9:"9 Seconds",
+                    10:"10 Seconds",
+                    20:"20 Seconds",
+                    30:"30 Seconds",
+                    40:"40 Seconds",
+                    50:"50 Seconds",
+                    60:"60 Seconds",
+                    62:"2 Minutes",
+                    63:"3 Minutes",
+                    64:"4 Minutes",
+                    65:"5 Minutes",
+                    255:"Indefinetly"]
+                input "parameter16-${i}d", "enum", title: "LED Effect Type - Notification $i", description: "Tap to set", displayDuringSetup: false, required: false, options: [
+                    0:"Off",
+                    1:"Solid",
+                    2:"Chase",
+                    3:"Fast Blink",
+                    4:"Slow Blink",
+                    5:"Pulse"]
+    
+    }
+    input "disableLocal", "enum", title: "Disable Local Control", description: "\nDisable ability to control switch from the wall", required: false, options:[["1": "Yes"], ["0": "No"]], defaultValue: "0"
+    input "disableRemote", "enum", title: "Disable Remote Control", description: "\nDisable ability to control switch from inside SmartThings", required: false, options:[["1": "Yes"], ["0": "No"]], defaultValue: "0"
+    input description: "Use the below options to enable child devices for the specified settings. This will allow you to adjust these settings using SmartApps such as Smart Lighting. If any of the options are enabled, make sure you have the appropriate child device handlers installed.\n(Firmware 1.02+)", title: "Child Devices", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+    input "enableDisableLocalChild", "bool", title: "Disable Local Control", description: "", required: false, defaultValue: false
+    input "enableDisableRemoteChild", "bool", title: "Disable Remote Control", description: "", required: false, defaultValue: false
+    input "enableDefaultLocalChild", "bool", title: "Default Level (Local)", description: "", required: false, defaultValue: false
+    input "enableDefaultZWaveChild", "bool", title: "Default Level (Z-Wave)", description: "", required: false, defaultValue: false
+    input name: "debugEnable", type: "bool", title: "Enable debug logging", defaultValue: true
+    input name: "infoEnable", type: "bool", title: "Enable informational logging", defaultValue: true
+}
+
+private channelNumber(String dni) {
+    dni.split("-ep")[-1] as Integer
+}
+
+private sendAlert(data) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Error while creating child device"
+    sendEvent(
+        descriptionText: data.message,
+        eventType: "ALERT",
+        name: "failedOperation",
+        value: "failed",
+        displayed: true,
+    )
+}
+
+private toggleTiles(number, value) {
+   for (int i = 1; i <= 5; i++){
+       if ("${i}" != number){
+           def childDevice = childDevices.find{it.deviceNetworkId == "$device.deviceNetworkId-ep$i"}
+           if (childDevice) {         
+                childDevice.sendEvent(name: "switch", value: "off")
+           }
+       } else {
+           def childDevice = childDevices.find{it.deviceNetworkId == "$device.deviceNetworkId-ep$i"}
+           if (childDevice) {         
+                childDevice.sendEvent(name: "switch", value: value)
+           }
+       }
+   }
+}
+
+def childSetLevel(String dni, value) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: childSetLevel($dni, $value)"
+    state.lastRan = now()
+    def valueaux = value as Integer
+    def level = Math.max(Math.min(valueaux, 99), 0)    
+    def cmds = []
+    switch (channelNumber(dni)) {
+        case 9:
+            cmds << new hubitat.device.HubAction(command(zwave.configurationV1.configurationSet(scaledConfigurationValue: value, parameterNumber: channelNumber(dni), size: 1) ), hubitat.device.Protocol.ZWAVE)
+            cmds << new hubitat.device.HubAction(command(zwave.configurationV1.configurationGet(parameterNumber: channelNumber(dni) )), hubitat.device.Protocol.ZWAVE)
+        break
+        case 10:
+            cmds << new hubitat.device.HubAction(command(zwave.configurationV1.configurationSet(scaledConfigurationValue: value, parameterNumber: channelNumber(dni), size: 1) ), hubitat.device.Protocol.ZWAVE)
+            cmds << new hubitat.device.HubAction(command(zwave.configurationV1.configurationGet(parameterNumber: channelNumber(dni) )), hubitat.device.Protocol.ZWAVE)
+        break
+        case 101:
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionSet(localProtectionState : level > 0 ? 1 : 0, rfProtectionState: state.rfProtectionState? state.rfProtectionState:0) ), hubitat.device.Protocol.ZWAVE)
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionGet() ), hubitat.device.Protocol.ZWAVE)
+        break
+        case 102:
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionSet(localProtectionState : state.localProtectionState? state.localProtectionState:0, rfProtectionState : level > 0 ? 1 : 0) ), hubitat.device.Protocol.ZWAVE)
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionGet() ), hubitat.device.Protocol.ZWAVE)
+        break
+    }
+	return cmds
+}
+
+def childOn(String dni) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: childOn($dni)"
+    state.lastRan = now()
+    def cmds = []
+    if(channelNumber(dni).toInteger() <= 5) {
+        toggleTiles("${channelNumber(dni)}", "on")
+        cmds << new hubitat.device.HubAction(command(setParameter(16, calculateParameter("16-${channelNumber(dni)}"), 4)), hubitat.device.Protocol.ZWAVE )
+        return cmds
+    } else {
+        childSetLevel(dni, 99)
+    }
+}
+
+def childOff(String dni) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: childOff($dni)"
+    state.lastRan = now()
+    def cmds = []
+    if(channelNumber(dni).toInteger() <= 5) {
+        toggleTiles("${channelNumber(dni)}", "off")
+        cmds << new hubitat.device.HubAction(command(setParameter(16, 0, 4)), hubitat.device.Protocol.ZWAVE )
+        return cmds
+    } else {
+        childSetLevel(dni, 0)
+    }
+}
+
+void childRefresh(String dni) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: childRefresh($dni)"
+}
+
+def childExists(ep) {
+    def children = childDevices
+    def childDevice = children.find{it.deviceNetworkId.endsWith(ep)}
+    if (childDevice) 
+        return true
+    else
+        return false
+}
+
+def installed() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: installed()"
+    refresh()
+}
+
+def configure() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: configure()"
+    def cmds = initialize()
+    commands(cmds)
+}
+
+def updated() {
+    if (!state.lastRan || now() >= state.lastRan + 2000) {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: updated()"
+        state.lastRan = now()
+        def cmds = initialize()
+        if (cmds != [])
+            commands(cmds, 1000)
+        else 
+            return null
+    } else {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: updated() ran within the last 2 seconds. Skipping execution."
+    }
+}
+
+def initialize() {
+    sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
+    sendEvent(name: "numberOfButtons", value: 8, displayed: true)
+    
+    if (enableDefaultLocalChild && !childExists("ep9")) {
+    try {
+        addChildDevice("Switch Level Child Device", "${device.deviceNetworkId}-ep9", 
+                [completedSetup: true, label: "${device.displayName} (Default Local Level)",
+                isComponent: true, componentName: "ep9", componentLabel: "Default Local Level"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
+    }
+    } else if (!enableDefaultLocalChild && childExists("ep9")) {
+        if (infoEnable) log.info "Trying to delete child device ep9. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep9")}
+        try {
+            if (infoEnable) log.info "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }
+    if (enableDefaultZWaveChild && !childExists("ep10")) {
+    try {
+        addChildDevice("Switch Level Child Device", "${device.deviceNetworkId}-ep10", 
+                [completedSetup: true, label: "${device.displayName} (Default Z-Wave Level)",
+                isComponent: true, componentName: "ep10", componentLabel: "Default Z-Wave Level"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
+    }
+    } else if (!enableDefaultLocalChild && childExists("ep10")) {
+        if (infoEnable) log.info "Trying to delete child device ep10. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep10")}
+        try {
+            if (infoEnable) log.info "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }
+    if (enableDisableLocalChild && !childExists("ep101")) {
+    try {
+        addChildDevice("Switch Level Child Device", "${device.deviceNetworkId}-ep101",
+                [completedSetup: true, label: "${device.displayName} (Disable Local Control)",
+                isComponent: true, componentName: "ep101", componentLabel: "Disable Local Control"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
+    }
+    } else if (!enableDisableLocalChild && childExists("ep101")) {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Trying to delete child device ep101. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
+        try {
+            if (infoEnable) log.info "${device.label?device.label:device.name}: SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }
+    if (enableDisableRemoteChild && !childExists("ep102")) {
+    try {
+        addChildDevice("Switch Level Child Device", "${device.deviceNetworkId}-ep102", 
+                [completedSetup: true, label: "${device.displayName} (Disable Remote Control)",
+                isComponent: true, componentName: "ep102", componentLabel: "Disable Remote Control"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
+    }
+    } else if (!enableDisableRemoteChild && childExists("ep102")) {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Trying to delete child device ep101. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep102")}
+        try {
+            if (infoEnable) log.info "${device.label?device.label:device.name}: SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }
+    
+    [1,2,3,4,5].each { i ->
+    if ((settings."parameter16-${i}a"!=null && settings."parameter16-${i}b"!=null && settings."parameter16-${i}c"!=null && settings."parameter16-${i}d"!=null) && !childExists("ep${i}")) {
+    try {
+        addChildDevice("Switch Child Device", "${device.deviceNetworkId}-ep${i}", 
+                [completedSetup: true, label: "${device.displayName} (Notification ${i})",
+                isComponent: true, componentName: "ep${i}", componentLabel: "Notification ${i}"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Child Device\" is installed"]])
+    }
+    } else if ((settings."parameter16-${i}a"==null || settings."parameter16-${i}b"==null || settings."parameter16-${i}c"==null || settings."parameter16-${i}d"==null) && childExists("ep${i}")) {
+        if (infoEnable) log.info "Trying to delete child device ep${i}. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep${i}")}
+        try {
+            if (infoEnable) log.info "SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }}
+    
+    if (device.label != state.oldLabel) {
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep1")}
+        if (childDevice) childDevice.setLabel("${device.displayName} (Notification 1)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep2")}
+        if (childDevice) childDevice.setLabel("${device.displayName} (Notification 2)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep3")}
+        if (childDevice) childDevice.setLabel("${device.displayName} (Notification 3)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep4")}
+        if (childDevice) childDevice.setLabel("${device.displayName} (Notification 4)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep5")}
+        if (childDevice) childDevice.setLabel("${device.displayName} (Notification 5)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep9")}
+        if (childDevice) childDevice.setLabel("${device.displayName} (Default Local Level)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep10")}
+        if (childDevice) childDevice.setLabel("${device.displayName} (Default Z-Wave Level)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
+        if (childDevice) childDevice.setLabel("${device.displayName} (Disable Local Control)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep102")}
+        if (childDevice) childDevice.setLabel("${device.displayName} (Disable Remote Control)")
+        state.oldLabel = device.label
+    }
+    
+    def cmds = processAssociations()
+    
+    getParameterNumbers().each{ i ->
+      if ((state."parameter${i}value" != ((settings."parameter${i}"!=null||calculateParameter(i)!=null)? calculateParameter(i).toInteger() : getParameterInfo(i, "default").toInteger()))){
+          if (infoEnable) log.info "Parameter $i is not set correctly. Setting it to ${settings."parameter${i}"!=null? calculateParameter(i).toInteger() : getParameterInfo(i, "default").toInteger()}."
+          cmds << setParameter(i, (settings."parameter${i}"!=null||calculateParameter(i)!=null)? calculateParameter(i).toInteger() : getParameterInfo(i, "default").toInteger(), getParameterInfo(i, "size").toInteger())
+          cmds << getParameter(i)
+      }
+      else {
+          if (infoEnable) log.info "${device.label?device.label:device.name}: Parameter $i already set"
+      }
+    }
+    
+    cmds << zwave.versionV1.versionGet()
+    
+    if (state.localProtectionState != settings.disableLocal || state.rfProtectionState != settings.disableRemote) {
+        cmds << zwave.protectionV2.protectionSet(localProtectionState : disableLocal!=null? disableLocal.toInteger() : 0, rfProtectionState: disableRemote!=null? disableRemote.toInteger() : 0)
+        cmds << zwave.protectionV2.protectionGet()
+    }
+
+    if (cmds != []) return cmds else return []
+}
+
+def calculateParameter(number) {
+    def value = 0
+    switch (number){
+      case "13":
+          if (settings.parameter13custom =~ /^([0-9]{1}|[0-9]{2}|[0-9]{3})$/) value = settings.parameter13custom.toInteger() / 360 * 255
+          else value = settings."parameter${number}"
+      break
+      case "16-1":
+      case "16-2":
+      case "16-3": 
+      case "16-4":
+      case "16-5":
+         value += settings."parameter${number}a"!=null ? settings."parameter${number}a".toInteger() * 1 : 0
+         value += settings."parameter${number}b"!=null ? settings."parameter${number}b".toInteger() * 256 : 0
+         value += settings."parameter${number}c"!=null ? settings."parameter${number}c".toInteger() * 65536 : 0
+         value += settings."parameter${number}d"!=null ? settings."parameter${number}d".toInteger() * 16777216 : 0
+      break
+      default:
+          value = settings."parameter${number}"
+      break
+    }
+    return value
+}
+
+def setParameter(number, value, size) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Setting parameter $number with a size of $size bytes to $value"
+    return zwave.configurationV1.configurationSet(configurationValue: integer2Cmd(value.toInteger(),size), parameterNumber: number, size: size)
+}
+
+def getParameter(number) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Retreiving value of parameter $number"
+    return zwave.configurationV1.configurationGet(parameterNumber: number)
+}
+def getParameterNumbers(){
+    return [1,2,3,4,5,6,7,8,9,10,11,13,14,15,17,18,19,20,21,22]
+}
+
+def getParameterInfo(number, value){
+    def parameter = [:]
+    
+    parameter.parameter1default=3
+    parameter.parameter2default=101
+    parameter.parameter3default=101
+    parameter.parameter4default=101
+    parameter.parameter5default=1
+    parameter.parameter6default=99
+    parameter.parameter7default=0
+    parameter.parameter8default=0
+    parameter.parameter9default=0
+    parameter.parameter10default=0
+    parameter.parameter11default=0
+    parameter.parameter12default=15
+    parameter.parameter13default=170
+    parameter.parameter14default=5
+    parameter.parameter15default=1
+    parameter.parameter16default=0
+    parameter.parameter17default=3
+    parameter.parameter18default=10
+    parameter.parameter19default=3600
+    parameter.parameter20default=10
+    parameter.parameter21default=1
+    parameter.parameter22default=0
+    
+    parameter.parameter1type="number"
+    parameter.parameter2type="number"
+    parameter.parameter3type="number"
+    parameter.parameter4type="number"
+    parameter.parameter5type="number"
+    parameter.parameter6type="number"
+    parameter.parameter7type="enum"
+    parameter.parameter8type="number"
+    parameter.parameter9type="number"
+    parameter.parameter10type="number"
+    parameter.parameter11type="number"
+    parameter.parameter12type="number"
+    parameter.parameter13type="enum"
+    parameter.parameter14type="enum"
+    parameter.parameter15type="enum"
+    parameter.parameter16type="enum"
+    parameter.parameter17type="enum"
+    parameter.parameter18type="number"
+    parameter.parameter19type="number"
+    parameter.parameter20type="number"
+    parameter.parameter21type="enum"
+    parameter.parameter22type="enum"
+    
+    parameter.parameter1size=1
+    parameter.parameter2size=1
+    parameter.parameter3size=1
+    parameter.parameter4size=1
+    parameter.parameter5size=1
+    parameter.parameter6size=1
+    parameter.parameter7size=1
+    parameter.parameter8size=2
+    parameter.parameter9size=1
+    parameter.parameter10size=1
+    parameter.parameter11size=1
+    parameter.parameter12size=1
+    parameter.parameter13size=2
+    parameter.parameter14size=1
+    parameter.parameter15size=1
+    parameter.parameter16size=4
+    parameter.parameter17size=1
+    parameter.parameter18size=1
+    parameter.parameter19size=2
+    parameter.parameter20size=1
+    parameter.parameter21size=1
+    parameter.parameter22size=1
+    
+    parameter.parameter1options="0..100"
+    parameter.parameter2options="0..101"
+    parameter.parameter3options="0..101"
+    parameter.parameter4options="0..101"
+    parameter.parameter5options="1..45"
+    parameter.parameter6options="55..99"
+    parameter.parameter7options=["1":"Yes", "0":"No"]
+    parameter.parameter8options="0..32767"
+    parameter.parameter9options="0..100"
+    parameter.parameter10options="0..100"
+    parameter.parameter11options="0..100"
+    parameter.parameter12options="0..15"
+    parameter.parameter13options=["0":"Red","21":"Orange","42":"Yellow","85":"Green","127":"Cyan","170":"Blue","212":"Violet","234":"Pink"]
+    parameter.parameter14options=["0":"0%","1":"10%","2":"20%","3":"30%","4":"40%","5":"50%","6":"60%","7":"70%","8":"80%","9":"90%","10":"100%"]
+    parameter.parameter15options=["0":"0%","1":"10%","2":"20%","3":"30%","4":"40%","5":"50%","6":"60%","7":"70%","8":"80%","9":"90%","10":"100%"]
+    parameter.parameter16options=["1":"Yes", "2":"No"]
+    parameter.parameter17options=["0":"Stay Off","1":"1 Second","2":"2 Seconds","3":"3 Seconds","4":"4 Seconds","5":"5 Seconds","6":"6 Seconds","7":"7 Seconds","8":"8 Seconds","9":"9 Seconds","10":"10 Seconds"]
+    parameter.parameter18options="0..100"
+    parameter.parameter19options="0..32767"
+    parameter.parameter20options="0..100"
+    parameter.parameter21options=["0":"Non Neutral", "1":"Neutral"]
+    parameter.parameter22options=["0":"Load Only", "1":"3-way Toggle", "2":"3-way Momentary"]
+    
+    parameter.parameter1name="Dimming Speed"
+    parameter.parameter2name="Dimming Speed (From Switch)"
+    parameter.parameter3name="Ramp Rate"
+    parameter.parameter4name="Ramp Rate (From Switch)"
+    parameter.parameter5name="Minimum Level"
+    parameter.parameter6name="Maximum Level"
+    parameter.parameter7name="Invert Switch"
+    parameter.parameter8name="Auto Off Timer"
+    parameter.parameter9name="Default Level (Local)"
+    parameter.parameter10name="Default Level (Z-Wave)"
+    parameter.parameter11name="State After Power Restored"
+    parameter.parameter12name="Association Behavior"
+    parameter.parameter13name="LED Strip Color"
+    parameter.parameter14name="LED Strip Intensity"
+    parameter.parameter15name="LED Strip Intensity (When OFF)"
+    parameter.parameter16name="LED Strip Effect"
+    parameter.parameter17name="LED Strip Timeout"
+    parameter.parameter18name="Active Power Reports"
+    parameter.parameter19name="Periodic Power & Energy Reports"
+    parameter.parameter20name="Energy Reports"
+    parameter.parameter21name="AC Power Type"
+    parameter.parameter22name="Switch Type"
+    
+    parameter.parameter1description="This changes the speed in which the attached light dims up or down. A setting of 0 should turn the light immediately on or off (almost like an on/off switch). Increasing the value should slow down the transition speed."
+    parameter.parameter2description="This changes the speed in which the attached light dims up or down when controlled from the physical switch. A setting of 0 should turn the light immediately on or off (almost like an on/off switch). Increasing the value should slow down the transition speed. A setting of 101 should keep this in sync with parameter 1."
+    parameter.parameter3description="This changes the speed in which the attached light turns on or off. For example, when a user sends the switch a basicSet(value: 0xFF) or basicSet(value: 0x00), this is the speed in which those actions take place. A setting of 0 should turn the light immediately on or off (almost like an on/off switch). Increasing the value should slow down the transition speed. A setting of 101 should keep this in sync with parameter 1."
+    parameter.parameter4description="This changes the speed in which the attached light turns on or off from the physical switch. For example, when a user presses the up or down button, this is the speed in which those actions take place. A setting of 0 should turn the light immediately on or off (almost like an on/off switch). Increasing the value should slow down the transition speed. A setting of 101 should keep this in sync with parameter 1."
+    parameter.parameter5description="The minimum level that the dimmer allows the bulb to be dimmed to. Useful when the user has an LED bulb that does not turn on or flickers at a lower level."
+    parameter.parameter6description="The maximum level that the dimmer allows the bulb to be dimmed to. Useful when the user has an LED bulb that reaches its maximum level before the dimmer value of 99."
+    parameter.parameter7description="Inverts the orientation of the switch. Useful when the switch is installed upside down. Essentially up becomes down and down becomes up."
+    parameter.parameter8description="Automatically turns the switch off after this many seconds. When the switch is turned on a timer is started that is the duration of this setting. When the timer expires, the switch is turned off."
+    parameter.parameter9description="Default level for the dimmer when it is powered on from the local switch. A setting of 0 means that the switch will return to the level that it was on before it was turned off."
+    parameter.parameter10description="Default level for the dimmer when it is powered on from a Z-Wave command. A setting of 0 means that the switch will return to the level that it was on before it was turned off."
+    parameter.parameter11description="The state the switch should return to once power is restored after power failure. 0 = off, 1-99 = level, 100=previous."
+    parameter.parameter12description="When should the switch send commands to associated devices?\n\n01 - local\n02 - 3way\n03 - 3way & local\n04 - z-wave hub\n05 - z-wave hub & local\n06 - z-wave hub & 3-way\n07 - z-wave hub & local & 3way\n08 - timer\n09 - timer & local\n10 - timer & 3-way\n11 - timer & 3-way & local\n12 - timer & z-wave hub\n13 - timer & z-wave hub & local\n14 - timer & z-wave hub & 3-way\n15 - all"
+    parameter.parameter13description="This is the color of the LED strip."
+    parameter.parameter14description="This is the intensity of the LED strip."
+    parameter.parameter15description="This is the intensity of the LED strip when the switch is off. This is useful for users to see the light switch location when the lights are off."
+    parameter.parameter16description="LED Strip Effect"
+    parameter.parameter17description="When the LED strip is disabled (LED Strip Intensity is set to 0), this setting allows the LED strip to turn on temporarily while being adjusted."
+    parameter.parameter18description="The power level change that will result in a new power report being sent. The value is a percentage of the previous report. 0 = disabled."
+    parameter.parameter19description="Time period between consecutive power & energy reports being sent (in seconds). The timer is reset after each report is sent."
+    parameter.parameter20description="The energy level change that will result in a new energy report being sent. The value is a percentage of the previous report."
+    parameter.parameter21description="Configure the switch to use a neutral wire."
+    parameter.parameter22description="Configure the type of 3-way switch connected to the dimmer."
+    
+    return parameter."parameter${number}${value}"
+}
+
+def zwaveEvent(hubitat.zwave.commands.meterv3.MeterReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    def event
+	if (cmd.scale == 0) {
+    	if (cmd.meterType == 161) {
+		    event = createEvent(name: "voltage", value: cmd.scaledMeterValue, unit: "V")
+            if (infoEnable) log.info "${device.label?device.label:device.name}: Voltage report received with value of ${cmd.scaledMeterValue} V"
+        } else if (cmd.meterType == 1) {
+        	event = createEvent(name: "energy", value: cmd.scaledMeterValue, unit: "kWh")
+            if (infoEnable) log.info "${device.label?device.label:device.name}: Energy report received with value of ${cmd.scaledMeterValue} kWh"
+        }
+	} else if (cmd.scale == 1) {
+		event = createEvent(name: "amperage", value: cmd.scaledMeterValue, unit: "A")
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Amperage report received with value of ${cmd.scaledMeterValue} A"
+	} else if (cmd.scale == 2) {
+		event = createEvent(name: "power", value: Math.round(cmd.scaledMeterValue), unit: "W")
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Power report received with value of ${cmd.scaledMeterValue} W"
+	}
+
+    return event
+}
+
+def zwaveEvent(hubitat.zwave.commands.configurationv1.ConfigurationReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: parameter '${cmd.parameterNumber}' with a byte size of '${cmd.size}' is set to '${cmd2Integer(cmd.configurationValue)}'"
+    if (!state.lastRan || now() <= state.lastRan + 60000) {
+        state."parameter${cmd.parameterNumber}value" = cmd2Integer(cmd.configurationValue)
+    } else {
+        if (infoEnable) log.debug "${device.label?device.label:device.name}: Configuration report received more than 60 seconds after running updated(). Possible configuration made at switch"
+    }
+    def integerValue = cmd2Integer(cmd.configurationValue)
+    switch (cmd.parameterNumber) {
+        case 9:
+            def children = childDevices
+            def childDevice = children.find{it.deviceNetworkId.endsWith("ep9")}
+            if (childDevice) {
+            childDevice.sendEvent(name: "switch", value: integerValue > 0 ? "on" : "off")
+            childDevice.sendEvent(name: "level", value: integerValue)            
+            }
+        break
+        case 10:
+            def children = childDevices
+            def childDevice = children.find{it.deviceNetworkId.endsWith("ep10")}
+            if (childDevice) {
+            childDevice.sendEvent(name: "switch", value: integerValue > 0 ? "on" : "off")
+            childDevice.sendEvent(name: "level", value: integerValue)
+            }
+        break
+    }
+}
+
+def cmd2Integer(array) {
+    switch(array.size()) {
+        case 1:
+            array[0]
+            break
+        case 2:
+            ((array[0] & 0xFF) << 8) | (array[1] & 0xFF)
+            break
+        case 3:
+            ((array[0] & 0xFF) << 16) | ((array[1] & 0xFF) << 8) | (array[2] & 0xFF)
+            break
+        case 4:
+            ((array[0] & 0xFF) << 24) | ((array[1] & 0xFF) << 16) | ((array[2] & 0xFF) << 8) | (array[3] & 0xFF)
+            break
+    }
+}
+
+def integer2Cmd(value, size) {
+    try{
+	switch(size) {
+	case 1:
+		[value]
+    break
+	case 2:
+    	def short value1   = value & 0xFF
+        def short value2 = (value >> 8) & 0xFF
+        [value2, value1]
+    break
+    case 3:
+    	def short value1   = value & 0xFF
+        def short value2 = (value >> 8) & 0xFF
+        def short value3 = (value >> 16) & 0xFF
+        [value3, value2, value1]
+    break
+	case 4:
+    	def short value1 = value & 0xFF
+        def short value2 = (value >> 8) & 0xFF
+        def short value3 = (value >> 16) & 0xFF
+        def short value4 = (value >> 24) & 0xFF
+		[value4, value3, value2, value1]
+	break
+	}
+    } catch (e) {
+        if (debugEnable) log.debug "Error: integer2Cmd $e Value: $value"
+    }
+}
+
+private getCommandClassVersions() {
+	[0x20: 1, 0x25: 1, 0x70: 1, 0x98: 1, 0x32: 3]
+}
+
+def zwaveEvent(hubitat.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
+    def encapsulatedCommand = cmd.encapsulatedCommand(commandClassVersions)
+    if (encapsulatedCommand) {
+        state.sec = 1
+        zwaveEvent(encapsulatedCommand)
+    }
+}
+
+def parse(description) {
+    def result = null
+    if (description.startsWith("Err 106")) {
+        state.sec = 0
+        result = createEvent(descriptionText: description, isStateChange: true)
+    } else if (description != "updated") {
+        def cmd = zwave.parse(description, commandClassVersions)
+        if (cmd) {
+            result = zwaveEvent(cmd)
+            //log.debug("'$cmd' parsed to $result")
+        } else {
+            if (debugEnable) log.debug "Couldn't zwave.parse '$description'" 
+        }
+    }
+    def now
+    if(location.timeZone)
+    now = new Date().format("yyyy MMM dd EEE h:mm:ss a", location.timeZone)
+    else
+    now = new Date().format("yyyy MMM dd EEE h:mm:ss a")
+    sendEvent(name: "lastActivity", value: now, displayed:false)
+    result
+}
+
+def zwaveEvent(hubitat.zwave.commands.basicv1.BasicReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Basic report received with value of ${cmd.value ? "on" : "off"} ($cmd.value)"
+    // Since SmartThings isn't filtering duplicate events, we are skipping these
+    // Switch is sending SwitchMultilevelReport as well (which we will use)
+    dimmerEvents(cmd)
+}
+
+def zwaveEvent(hubitat.zwave.commands.basicv1.BasicSet cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Basic set received with value of ${cmd.value ? "on" : "off"}"
+    dimmerEvents(cmd)
+}
+
+def zwaveEvent(hubitat.zwave.commands.switchbinaryv1.SwitchBinaryReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Switch Binary report received with value of ${cmd.value ? "on" : "off"}"
+    dimmerEvents(cmd)
+}
+
+def zwaveEvent(hubitat.zwave.commands.switchmultilevelv3.SwitchMultilevelReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Switch Multilevel report received with value of ${cmd.value ? "on" : "off"} ($cmd.value)"
+    dimmerEvents(cmd)
+}
+
+private dimmerEvents(hubitat.zwave.Command cmd) {
+    def value = (cmd.value ? "on" : "off")
+    def result = [createEvent(name: "switch", value: value)]
+    if (cmd.value) {
+        result << createEvent(name: "level", value: cmd.value, unit: "%")
+    }
+    return result
+}
+
+def zwaveEvent(hubitat.zwave.commands.centralscenev1.CentralSceneNotification cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    switch (cmd.keyAttributes) {
+       case 0:
+       if (cmd.sceneNumber == 3) createEvent(buttonEvent(7, "pushed", "physical"))
+       else createEvent(buttonEvent(cmd.keyAttributes + 1, (cmd.sceneNumber == 2? "pushed" : "held"), "physical"))
+       break
+       case 1:
+       createEvent(buttonEvent(6, (cmd.sceneNumber == 2? "pushed" : "held"), "physical"))
+       break
+       case 2:
+       createEvent(buttonEvent(8, (cmd.sceneNumber == 2? "pushed" : "held"), "physical"))
+       break
+       default:
+       createEvent(buttonEvent(cmd.keyAttributes - 1, (cmd.sceneNumber == 2? "pushed" : "held"), "physical"))
+       break
+    }
+}
+
+def buttonEvent(button, value, type = "digital") {
+    if(button != 6)
+        sendEvent(name:"lastEvent", value: "${value != 'pushed'?' Tap '.padRight(button+5, '▼'):' Tap '.padRight(button+5, '▲')}", displayed:false)
+    else
+        sendEvent(name:"lastEvent", value: "${value != 'pushed'?' Hold ▼':' Hold ▲'}", displayed:false)
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Button ${button} was ${value}"
+    [name: value, value: button, isStateChange:true]
+}
+
+def zwaveEvent(hubitat.zwave.Command cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: Unhandled: $cmd"
+    null
+}
+
+def reset() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Resetting energy statistics"
+	def cmds = []
+    cmds << zwave.meterV2.meterReset()
+    cmds << zwave.meterV2.meterGet(scale: 0)
+    cmds << zwave.meterV2.meterGet(scale: 2)
+	commands(cmds, 1000)
+}
+
+def on() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: on()"
+    commands([
+        zwave.switchMultilevelV1.switchMultilevelSet(value: 0xFF)//,
+        //zwave.switchMultilevelV1.switchMultilevelGet()
+    ])
+}
+
+def off() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: off()"
+    commands([
+        zwave.switchMultilevelV1.switchMultilevelSet(value: 0x00)//,
+        //zwave.switchMultilevelV1.switchMultilevelGet()
+    ])
+}
+
+def setLevel(value) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: setLevel($value)"
+    commands([
+        zwave.basicV1.basicSet(value: value < 100 ? value : 99)//,
+        //zwave.basicV1.basicGet()
+    ])
+}
+
+def setLevel(value, duration) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: setLevel($value, $duration)"
+    def dimmingDuration = duration < 128 ? duration : 128 + Math.round(duration / 60)
+    commands([
+        zwave.switchMultilevelV2.switchMultilevelSet(value: value < 100 ? value : 99, dimmingDuration: dimmingDuration)//,
+        //zwave.switchMultilevelV1.switchMultilevelGet()
+    ])
+}
+
+def ping() {
+    if (debugEnable) log.debug "ping()"
+    refresh()
+}
+
+def poll() {
+    if (debugEnable) log.debug "poll()"
+    refresh()
+}
+
+def refresh() {
+    if (debugEnable) log.debug "refresh()"
+    def cmds = []
+    cmds << zwave.switchMultilevelV1.switchMultilevelGet()
+    cmds << zwave.meterV3.meterGet(scale: 0)
+	cmds << zwave.meterV3.meterGet(scale: 2)
+    return commands(cmds)
+}
+
+private command(hubitat.zwave.Command cmd) {
+    if (state.sec) {
+        zwave.securityV1.securityMessageEncapsulation().encapsulate(cmd).format()
+    } else {
+        cmd.format()
+    }
+}
+
+private commands(commands, delay=1000) {
+    delayBetween(commands.collect{ command(it) }, delay)
+}
+
+def pressUpX1() {
+    sendEvent(buttonEvent(1, "pushed"))
+}
+
+def pressDownX1() {
+    sendEvent(buttonEvent(1, "held"))
+}
+
+def pressUpX2() {
+    sendEvent(buttonEvent(2, "pushed"))
+}
+
+def pressDownX2() {
+    sendEvent(buttonEvent(2, "held"))
+}
+
+def pressUpX3() {
+    sendEvent(buttonEvent(3, "pushed"))
+}
+
+def pressDownX3() {
+    sendEvent(buttonEvent(3, "held"))
+}
+
+def pressUpX4() {
+    sendEvent(buttonEvent(4, "pushed"))
+}
+
+def pressDownX4() {
+    sendEvent(buttonEvent(4, "held"))
+}
+
+def pressUpX5() {
+    sendEvent(buttonEvent(5, "pushed"))
+}
+
+def pressDownX5() {
+    sendEvent(buttonEvent(5, "held"))
+}
+
+def holdUp() {
+    sendEvent(buttonEvent(6, "pushed"))
+}
+
+def holdDown() {
+    sendEvent(buttonEvent(6, "held"))
+}
+
+def pressConfig() {
+    sendEvent(buttonEvent(7, "pushed"))
+}
+
+def setDefaultAssociations() {
+    def smartThingsHubID = String.format('%02x', zwaveHubNodeId).toUpperCase()
+    state.defaultG1 = [smartThingsHubID]
+    state.defaultG2 = []
+    state.defaultG3 = []
+}
+
+def setAssociationGroup(group, node, action, endpoint = null){
+    if (! node =~ /[0-9A-F]+/)
+        return
+
+    if (group < 1 || group > maxAssociationGroup())
+        return
+    
+    def associations = state."desiredAssociation${group}"?:[]
+    switch (action) {
+        case "Remove":
+        associations = associations - node
+        break
+        case "Add":
+        associations << node
+        break
+    }
+    state."desiredAssociation${group}" = associations.unique()
+    return
+}
+
+def maxAssociationGroup(){
+   if (!state.associationGroups) {
+       if (logEnable) log.debug "Getting supported association groups from device"
+       zwave.associationV2.associationGroupingsGet() // execute the update immediately
+   }
+   (state.associationGroups?: 5) as int
+}
+
+def processAssociations(){
+   def cmds = []
+   setDefaultAssociations()
+   def associationGroups = maxAssociationGroup()
+   for (int i = 1; i <= associationGroups; i++){
+      if(state."actualAssociation${i}" != null){
+         if(state."desiredAssociation${i}" != null || state."defaultG${i}") {
+            def refreshGroup = false
+            ((state."desiredAssociation${i}"? state."desiredAssociation${i}" : [] + state."defaultG${i}") - state."actualAssociation${i}").each {
+                if (logEnable) log.debug "Adding node $it to group $i"
+                cmds << zwave.associationV2.associationSet(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
+                refreshGroup = true
+            }
+            ((state."actualAssociation${i}" - state."defaultG${i}") - state."desiredAssociation${i}").each {
+                if (logEnable) log.debug "Removing node $it from group $i"
+                cmds << zwave.associationV2.associationRemove(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
+                refreshGroup = true
+            }
+            if (refreshGroup == true) cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
+            else if (logEnable) log.debug "There are no association actions to complete for group $i"
+         }
+      } else {
+         if (logEnable) log.debug "Association info not known for group $i. Requesting info from device."
+         cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
+      }
+   }
+   return cmds
+}
+
+def zwaveEvent(hubitat.zwave.commands.associationv2.AssociationReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    def temp = []
+    if (cmd.nodeId != []) {
+       cmd.nodeId.each {
+          temp += it.toString().format( '%02x', it.toInteger() ).toUpperCase()
+       }
+    } 
+    state."actualAssociation${cmd.groupingIdentifier}" = temp
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Associations for Group ${cmd.groupingIdentifier}: ${temp}"
+    updateDataValue("associationGroup${cmd.groupingIdentifier}", "$temp")
+}
+
+def zwaveEvent(hubitat.zwave.commands.associationv2.AssociationGroupingsReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    sendEvent(name: "groups", value: cmd.supportedGroupings)
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Supported association groups: ${cmd.supportedGroupings}"
+    state.associationGroups = cmd.supportedGroupings
+}
+
+def zwaveEvent(hubitat.zwave.commands.versionv1.VersionReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    if(cmd.applicationVersion != null && cmd.applicationSubVersion != null) {
+	    def firmware = "${cmd.applicationVersion}.${cmd.applicationSubVersion.toString().padLeft(2,'0')}"
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Firmware report received: ${firmware}"
+        state.needfwUpdate = "false"
+        createEvent(name: "firmware", value: "${firmware}")
+    }
+}
+
+def zwaveEvent(hubitat.zwave.commands.protectionv2.ProtectionReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Protection report received: Local protection is ${cmd.localProtectionState > 0 ? "on" : "off"} & Remote protection is ${cmd.rfProtectionState > 0 ? "on" : "off"}"
+    if (!state.lastRan || now() <= state.lastRan + 60000) {
+        state.localProtectionState = cmd.localProtectionState
+        state.rfProtectionState = cmd.rfProtectionState
+    } else {
+        if (infoEnable) log.debug "${device.label?device.label:device.name}: Protection report received more than 60 seconds after running updated(). Possible configuration made at switch"
+    }
+    //device.updateSetting("disableLocal",[value:cmd.localProtectionState?cmd.localProtectionState:0,type:"enum"])
+    //device.updateSetting("disableRemote",[value:cmd.rfProtectionState?cmd.rfProtectionState:0,type:"enum"])
+    def children = childDevices
+    def childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
+    if (childDevice) {
+        childDevice.sendEvent(name: "switch", value: cmd.localProtectionState > 0 ? "on" : "off")        
+    }
+    childDevice = children.find{it.deviceNetworkId.endsWith("ep102")}
+    if (childDevice) {
+        childDevice.sendEvent(name: "switch", value: cmd.rfProtectionState > 0 ? "on" : "off")        
+    }
+}

--- a/Drivers/inovelli-dimmer-smart-plug-nzw39-w-scene.src/inovelli-dimmer-smart-plug-nzw39-w-scene.groovy
+++ b/Drivers/inovelli-dimmer-smart-plug-nzw39-w-scene.src/inovelli-dimmer-smart-plug-nzw39-w-scene.groovy
@@ -1,7 +1,4 @@
 /**
- *
- *  Hubitat Import URL: https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-dimmer-smart-plug-nzw39-w-scene.src/inovelli-dimmer-smart-plug-nzw39-w-scene.groovy
- *
  *  Inovelli Dimmer Smart Plug NZW39 w/Scene
  *  Author: Eric Maycock (erocm123)
  *  Date: 2017-10-18
@@ -20,7 +17,12 @@
  */
  
 metadata {
-    definition (name: "Inovelli Dimmer Smart Plug NZW39 w/Scene", namespace: "InovelliUSA", author: "Eric Maycock") {
+    definition (
+        name: "Inovelli Dimmer Smart Plug NZW39 w/Scene", 
+        namespace: "InovelliUSA", 
+        author: "Eric Maycock",
+        importUrl: "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-dimmer-smart-plug-nzw39-w-scene.src/inovelli-dimmer-smart-plug-nzw39-w-scene.groovy"
+    ) {
         capability "Switch"
         capability "Refresh"
         capability "Polling"
@@ -47,6 +49,7 @@ metadata {
         input "autoOff", "number", title: "Auto Off\n\nAutomatically turn switch off after this number of seconds\nRange: 0 to 32767", description: "Tap to set", required: false, range: "0..32767"
         input "ledIndicator", "enum", title: "LED Indicator\n\nTurn LED indicator on when light is:\n", description: "Tap to set", required: false, options:[[1: "On"], [0: "Off"], [2: "Disable"]], defaultValue: 1     
         input description: "1 pushed - Button 2x click", title: "Button Mappings", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+	input name: "logEnable", type: "bool", title: "Enable debug logging", defaultValue: true	    
     }
     
     tiles {
@@ -117,7 +120,7 @@ def integer2Cmd(value, size) {
 	break
 	}
     } catch (e) {
-        log.debug "Error: integer2Cmd $e Value: $value"
+        if (logEnable) log.debug "Error: integer2Cmd $e Value: $value"
     }
 }
 
@@ -145,9 +148,9 @@ def parse(description) {
         def cmd = zwave.parse(description, [0x20: 1, 0x25: 1, 0x70: 1, 0x98: 1])
         if (cmd) {
             result = zwaveEvent(cmd)
-            log.debug("'$description' parsed to $result")
+            if (logEnable) log.debug("'$description' parsed to $result")
         } else {
-            log.debug("Couldn't zwave.parse '$description'")
+            if (logEnable) log.debug("Couldn't zwave.parse '$description'")
         }
     }
     def now
@@ -206,7 +209,7 @@ def buttonEvent(button, value, type = "digital") {
 }
 
 def zwaveEvent(hubitat.zwave.Command cmd) {
-    log.debug "Unhandled: $cmd"
+    if (logEnable) log.debug "Unhandled: $cmd"
     null
 }
 
@@ -240,17 +243,17 @@ def setLevel(value, duration) {
 }
 
 def ping() {
-    log.debug "ping()"
+    if (logEnable) log.debug "ping()"
     refresh()
 }
 
 def poll() {
-    log.debug "poll()"
+    if (logEnable) log.debug "poll()"
     refresh()
 }
 
 def refresh() {
-    log.debug "refresh()"
+    if (logEnable) log.debug "refresh()"
     commands([zwave.switchBinaryV1.switchBinaryGet(),
               zwave.switchMultilevelV1.switchMultilevelGet()
     ])

--- a/Drivers/inovelli-dimmer-smart-plug-nzw39.src/inovelli-dimmer-smart-plug-nzw39.groovy
+++ b/Drivers/inovelli-dimmer-smart-plug-nzw39.src/inovelli-dimmer-smart-plug-nzw39.groovy
@@ -1,7 +1,4 @@
 /**
- *
- *  Hubitat Import URL: https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-dimmer-smart-plug-nzw39.src/inovelli-dimmer-smart-plug-nzw39.groovy
- *
  *  Copyright 2015 SmartThings
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -15,7 +12,13 @@
  *
  */
 metadata {
-	definition (name: "Inovelli Dimmer Smart Plug NZW39", namespace: "InovelliUSA", author: "SmartThings", ocfDeviceType: "oic.d.light") {
+	definition (
+        name: "Inovelli Dimmer Smart Plug NZW39", 
+        namespace: "InovelliUSA", 
+        author: "SmartThings", 
+        ocfDeviceType: "oic.d.light",
+        importUrl: "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-dimmer-smart-plug-nzw39.src/inovelli-dimmer-smart-plug-nzw39.groovy"
+    ) {
 		capability "Switch Level"
 		capability "Actuator"
 		capability "Switch"

--- a/Drivers/inovelli-door-window-sensor-nzw1201.src/inovelli-door-window-sensor-nzw1201.groovy
+++ b/Drivers/inovelli-door-window-sensor-nzw1201.src/inovelli-door-window-sensor-nzw1201.groovy
@@ -323,21 +323,35 @@ def setDefaultAssociations() {
     state.defaultG3 = []
 }
 
-def setAssociationGroup(group, node, action, endpoint = null){
-    if (! node =~ /[0-9A-F]+/)
-        return
+def setAssociationGroup(group, nodes, action, endpoint = null){
+    // Normalize the arguments to be backwards compatible with the old method
+    action = "${action}" == "1" ? "Add" : "${action}" == "0" ? "Remove" : "${action}" // convert 1/0 to Add/Remove
+    group  = "${group}" =~ /\d+/ ? (group as int) : group                             // convert group to int (if possible)
+    nodes  = [] + nodes ?: [nodes]                                                    // convert to collection if not already a collection
 
-    if (group < 1 || group > maxAssociationGroup())
+    if (! nodes.every { it =~ /[0-9A-F]+/ }) {
+        log.error "invalid Nodes ${nodes}"
         return
+    }
+
+    if (group < 1 || group > maxAssociationGroup()) {
+        log.error "Association group is invalid 1 <= ${group} <= ${maxAssociationGroup()}"
+        return
+    }
     
     def associations = state."desiredAssociation${group}"?:[]
-    switch (action) {
-        case "Remove":
-        associations = associations - node
-        break
-        case "Add":
-        associations << node
-        break
+    nodes.each { 
+        node = "${it}"
+        switch (action) {
+            case "Remove":
+            if (logEnable) log.debug "Removing node ${node} from association group ${group}"
+            associations = associations - node
+            break
+            case "Add":
+            if (logEnable) log.debug "Adding node ${node} to association group ${group}"
+            associations << node
+            break
+        }
     }
     state."desiredAssociation${group}" = associations.unique()
     return

--- a/Drivers/inovelli-switch-lzw30.src/inovelli-switch-lzw30.groovy
+++ b/Drivers/inovelli-switch-lzw30.src/inovelli-switch-lzw30.groovy
@@ -565,21 +565,35 @@ def setDefaultAssociations() {
     state.defaultG3 = []
 }
 
-def setAssociationGroup(group, node, action, endpoint = null){
-    if (! node =~ /[0-9A-F]+/)
-        return
+def setAssociationGroup(group, nodes, action, endpoint = null){
+    // Normalize the arguments to be backwards compatible with the old method
+    action = "${action}" == "1" ? "Add" : "${action}" == "0" ? "Remove" : "${action}" // convert 1/0 to Add/Remove
+    group  = "${group}" =~ /\d+/ ? (group as int) : group                             // convert group to int (if possible)
+    nodes  = [] + nodes ?: [nodes]                                                    // convert to collection if not already a collection
 
-    if (group < 1 || group > maxAssociationGroup())
+    if (! nodes.every { it =~ /[0-9A-F]+/ }) {
+        log.error "invalid Nodes ${nodes}"
         return
+    }
+
+    if (group < 1 || group > maxAssociationGroup()) {
+        log.error "Association group is invalid 1 <= ${group} <= ${maxAssociationGroup()}"
+        return
+    }
     
     def associations = state."desiredAssociation${group}"?:[]
-    switch (action) {
-        case "Remove":
-        associations = associations - node
-        break
-        case "Add":
-        associations << node
-        break
+    nodes.each { 
+        node = "${it}"
+        switch (action) {
+            case "Remove":
+            if (logEnable) log.debug "Removing node ${node} from association group ${group}"
+            associations = associations - node
+            break
+            case "Add":
+            if (logEnable) log.debug "Adding node ${node} to association group ${group}"
+            associations << node
+            break
+        }
     }
     state."desiredAssociation${group}" = associations.unique()
     return

--- a/Drivers/inovelli-switch-lzw30.src/inovelli-switch-lzw30.groovy
+++ b/Drivers/inovelli-switch-lzw30.src/inovelli-switch-lzw30.groovy
@@ -1,0 +1,672 @@
+/**
+ *  Inovelli Switch LZW30
+ *  Author: Eric Maycock (erocm123)
+ *  Date: 2019-10-15
+ *
+ *  Copyright 2019 Eric Maycock / Inovelli
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ *  2019-11-20: Fixed Association Group management.
+ *
+ *  2019-10-15: Ability to create child devices for local & rf protection to use in various automations.
+ *              Device label is now displayed in logging. 
+ * 
+ *  2019-10-01: Adding the ability to set a custom color for the RGB indicator. Use a hue 360 color wheel.
+ *              Adding the ability to enable z-wave "rf protection" to disable control from z-wave commands.
+ *
+ */
+ 
+metadata {
+    definition (name: "Inovelli Switch LZW30", namespace: "InovelliUSA", author: "Eric Maycock", vid: "generic-switch", importUrl: "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-switch-lzw30.src/inovelli-switch-lzw30.groovy") {
+        capability "Switch"
+        capability "Refresh"
+        capability "Actuator"
+        capability "Sensor"
+        capability "Configuration"
+        
+        attribute "lastActivity", "String"
+        attribute "lastEvent", "String"
+        attribute "firmware", "String"
+        
+        
+        command "childOn"
+        command "childOff"
+        command "childRefresh"
+        
+        command "setAssociationGroup", [[name: "Group Number*",type:"NUMBER", description: "Provide the association group number to edit"], 
+                                        [name: "Z-Wave Node*", type:"STRING", description: "Enter the node number (in hex) associated with the node"], 
+                                        [name: "Action*", type:"ENUM", constraints: ["Add", "Remove"]],
+                                        [name:"Multi-channel Endpoint", type:"NUMBER", description: "Currently not implemented"]] 
+
+        fingerprint mfr: "031E", prod: "0004", model: "0001", deviceJoinName: "Inovelli Switch"
+        fingerprint deviceId: "0x1001", inClusters: "0x5E,0x70,0x85,0x59,0x55,0x86,0x72,0x5A,0x73,0x98,0x9F,0x25,0x6C,0x75,0x22,0x7A" 
+        fingerprint deviceId: "0x1001", inClusters: "0x5E,0x55,0x98,0x9F,0x6C,0x22,0x70,0x85,0x59,0x86,0x25,0x72,0x5A,0x5B,0x73,0x75,0x7A" 
+    }
+
+    simulator {
+    }
+    
+    preferences {
+        generate_preferences()
+    }
+}
+
+def generate_preferences()
+{
+    getParameterNumbers().each { i ->
+        
+        switch(getParameterInfo(i, "type"))
+        {   
+            case "number":
+                input "parameter${i}", "number",
+                    title:getParameterInfo(i, "name") + "\n" + getParameterInfo(i, "description") + "\nRange: " + getParameterInfo(i, "options") + "\nDefault: " + getParameterInfo(i, "default"),
+                    range: getParameterInfo(i, "options")
+                    //defaultValue: getParameterInfo(i, "default")
+            break
+            case "enum":
+                input "parameter${i}", "enum",
+                    title:getParameterInfo(i, "name") + "\n" + getParameterInfo(i, "description"), 
+                    //defaultValue: getParameterInfo(i, "default"),
+                    options: getParameterInfo(i, "options")
+            break
+        } 
+        if (i == 5){
+           input "parameter5custom", "number", 
+               title: "Custom LED RGB Value", 
+               description: "\nInput a custom value in this field to override the above setting. The value should be between 0 - 360 and can be determined by using the typical hue color wheel.", 
+               required: false,
+               range: "0..360"
+        }
+    }
+    input "disableLocal", "enum", title: "Disable Local Control", description: "\nDisable ability to control switch from the wall", required: false, options:[["1": "Yes"], ["0": "No"]], defaultValue: "0"
+    input "disableRemote", "enum", title: "Disable Remote Control", description: "\nDisable ability to control switch from inside SmartThings", required: false, options:[["1": "Yes"], ["0": "No"]], defaultValue: "0"
+    input description: "Use the below options to enable child devices for the specified settings. This will allow you to adjust these settings using SmartApps such as Smart Lighting. If any of the options are enabled, make sure you have the appropriate child device handlers installed.\n(Firmware 1.02+)", title: "Child Devices", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+    input "enableDisableLocalChild", "bool", title: "Disable Local Control", description: "", required: false, defaultValue: false
+    input "enableDisableRemoteChild", "bool", title: "Disable Remote Control", description: "", required: false, defaultValue: false
+    input name: "debugEnable", type: "bool", title: "Enable debug logging", defaultValue: true
+    input name: "infoEnable", type: "bool", title: "Enable informational logging", defaultValue: true
+}
+
+private channelNumber(String dni) {
+    dni.split("-ep")[-1] as Integer
+}
+
+private sendAlert(data) {
+    sendEvent(
+        descriptionText: data.message,
+        eventType: "ALERT",
+        name: "failedOperation",
+        value: "failed",
+        displayed: true,
+    )
+}
+
+def childSetLevel(String dni, value) {
+    def valueaux = value as Integer
+    def level = Math.max(Math.min(valueaux, 99), 0)    
+    def cmds = []
+    switch (channelNumber(dni)) {
+        case 101:
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionSet(localProtectionState : level > 0 ? 1 : 0, rfProtectionState: state.rfProtectionState? state.rfProtectionState:0) ), hubitat.device.Protocol.ZWAVE)
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionGet() ), hubitat.device.Protocol.ZWAVE)
+        break
+        case 102:
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionSet(localProtectionState : state.localProtectionState? state.localProtectionState:0, rfProtectionState : level > 0 ? 1 : 0) ), hubitat.device.Protocol.ZWAVE)
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionGet() ), hubitat.device.Protocol.ZWAVE)
+        break
+    }
+	return cmds
+}
+
+private toggleTiles(number, value) {
+   for (int i = 1; i <= 5; i++){
+       if ("${i}" != number){
+           def childDevice = childDevices.find{it.deviceNetworkId == "$device.deviceNetworkId-ep$i"}
+           if (childDevice) {         
+                childDevice.sendEvent(name: "switch", value: "off")
+           }
+       } else {
+           def childDevice = childDevices.find{it.deviceNetworkId == "$device.deviceNetworkId-ep$i"}
+           if (childDevice) {         
+                childDevice.sendEvent(name: "switch", value: value)
+           }
+       }
+   }
+}
+
+def childOn(String dni) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: childOn($dni)"
+    def cmds = []
+    if(channelNumber(dni).toInteger() <= 5) {
+        toggleTiles("${channelNumber(dni)}", "on")
+        cmds << new hubitat.device.HubAction(command(setParameter(8, calculateParameter("8-${channelNumber(dni)}"), 4)) )
+        return cmds
+    } else {
+        childSetLevel(dni, 99)
+    }
+}
+
+def childOff(String dni) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: childOff($dni)"
+    def cmds = []
+    if(channelNumber(dni).toInteger() <= 5) {
+        toggleTiles("${channelNumber(dni)}", "off")
+        cmds << new hubitat.device.HubAction(command(setParameter(8, 0, 4)) )
+        return cmds
+    } else {
+        childSetLevel(dni, 0)
+    }
+}
+
+def childRefresh(String dni) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: childRefresh($dni)"
+}
+
+def childExists(ep) {
+    def children = childDevices
+    def childDevice = children.find{it.deviceNetworkId.endsWith(ep)}
+    if (childDevice) 
+        return true
+    else
+        return false
+}
+
+def installed() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: installed()"
+    refresh()
+}
+
+def configure() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: configure()"
+    def cmds = initialize()
+    commands(cmds)
+}
+
+def updated() {
+    if (!state.lastRan || now() >= state.lastRan + 2000) {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: updated()"
+        state.lastRan = now()
+        def cmds = initialize()
+        if (cmds != [])
+            commands(cmds, 1000)
+        else 
+            return null
+    } else {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: updated() ran within the last 2 seconds. Skipping execution."
+    }
+}
+
+def initialize() {
+    sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
+    
+    if (enableDisableLocalChild && !childExists("ep101")) {
+    try {
+        addChildDevice("Switch Level Child Device", "${device.deviceNetworkId}-ep101",
+                [completedSetup: true, label: "${device.displayName} (Disable Local Control)",
+                isComponent: true, componentName: "ep101", componentLabel: "Disable Local Control"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
+    }
+    } else if (!enableDisableLocalChild && childExists("ep101")) {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Trying to delete child device ep101. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
+        try {
+            if (infoEnable) log.info "${device.label?device.label:device.name}: SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }
+    if (enableDisableRemoteChild && !childExists("ep102")) {
+    try {
+        addChildDevice("Switch Level Child Device", "${device.deviceNetworkId}-ep102", 
+                [completedSetup: true, label: "${device.displayName} (Disable Remote Control)",
+                isComponent: true, componentName: "ep102", componentLabel: "Disable Remote Control"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
+    }
+    } else if (!enableDisableRemoteChild && childExists("ep102")) {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Trying to delete child device ep101. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep102")}
+        try {
+            if (infoEnable) log.info "${device.label?device.label:device.name}: SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }
+    
+    if (device.label != state.oldLabel) {
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Disable Local Control)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep102")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Disable Remote Control)")
+        state.oldLabel = device.label
+    }
+    
+    def cmds = processAssociations()
+    
+    getParameterNumbers().each{ i ->
+      if ((state."parameter${i}value" != ((settings."parameter${i}"!=null||calculateParameter(i)!=null)? calculateParameter(i).toInteger() : getParameterInfo(i, "default").toInteger()))){
+          cmds << setParameter(i, (settings."parameter${i}"!=null||calculateParameter(i)!=null)? calculateParameter(i).toInteger() : getParameterInfo(i, "default").toInteger(), getParameterInfo(i, "size").toInteger())
+          cmds << getParameter(i)
+      }
+      else {
+          //if (infoEnable) log.info "${device.label?device.label:device.name}: Parameter already set"
+      }
+    }
+
+    cmds << zwave.versionV1.versionGet()
+    
+    if (state.localProtectionState != settings.disableLocal || state.rfProtectionState != settings.disableRemote) {
+        cmds << zwave.protectionV2.protectionSet(localProtectionState : disableLocal!=null? disableLocal.toInteger() : 0, rfProtectionState: disableRemote!=null? disableRemote.toInteger() : 0)
+        cmds << zwave.protectionV2.protectionGet()
+    }
+
+    if (cmds != []) return cmds else return []
+}
+
+def calculateParameter(number) {
+    def value = 0
+    switch (number){
+      case "5":
+          if (settings.parameter5custom =~ /^([0-9]{1}|[0-9]{2}|[0-9]{3})$/) value = settings.parameter5custom.toInteger() / 360 * 255
+          else value = settings."parameter${number}"
+      break
+      case "8-1":
+      case "8-2":
+      case "8-3": 
+      case "8-4":
+      case "8-5":
+         value += settings."parameter${number}a"!=null ? settings."parameter${number}a".toInteger() * 1 : 0
+         value += settings."parameter${number}b"!=null ? settings."parameter${number}b".toInteger() * 256 : 0
+         value += settings."parameter${number}c"!=null ? settings."parameter${number}c".toInteger() * 65536 : 0
+         value += settings."parameter${number}d"!=null ? settings."parameter${number}d".toInteger() * 16777216 : 0
+      break
+      default:
+          value = settings."parameter${number}"
+      break
+    }
+    return value
+}
+
+def setParameter(number, value, size) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Setting parameter $number with a size of $size bytes to $value"
+    return zwave.configurationV1.configurationSet(configurationValue: integer2Cmd(value.toInteger(),size), parameterNumber: number, size: size)
+}
+
+def getParameter(number) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Retreiving value of parameter $number"
+    return zwave.configurationV1.configurationGet(parameterNumber: number)
+}
+
+def getParameterNumbers(){
+    return [1,2,3,4,5,6,7]
+}
+
+def getParameterInfo(number, type){
+    def parameter = [:]
+
+    parameter.parameter1default=0
+    parameter.parameter2default=0
+    parameter.parameter3default=0
+    parameter.parameter4default=15
+    parameter.parameter5default=170
+    parameter.parameter6default=5
+    parameter.parameter7default=1
+    parameter.parameter8default=0
+    parameter.parameter9default=0
+    parameter.parameter10default=10
+    parameter.parameter11default=3600
+    parameter.parameter12default=10
+    
+    parameter.parameter1type="enum"
+    parameter.parameter2type="enum"
+    parameter.parameter3type="number"
+    parameter.parameter4type="number"
+    parameter.parameter5type="enum"
+    parameter.parameter6type="enum"
+    parameter.parameter7type="enum"
+    parameter.parameter8type="enum"
+    parameter.parameter9type="enum"
+    parameter.parameter10type="number"
+    parameter.parameter11type="number"
+    parameter.parameter12type="number"
+    
+    parameter.parameter1size=1
+    parameter.parameter2size=1
+    parameter.parameter3size=2
+    parameter.parameter4size=1
+    parameter.parameter5size=2
+    parameter.parameter6size=1
+    parameter.parameter7size=1
+    parameter.parameter8size=4
+    parameter.parameter9size=1
+    parameter.parameter10size=1
+    parameter.parameter11size=2
+    parameter.parameter12size=1
+    
+	parameter.parameter1options=["0":"Previous", "1":"On", "2":"Off"]
+    parameter.parameter2options=["1":"Yes", "0":"No"]
+    parameter.parameter3options="1..32767"
+    parameter.parameter4options="0..15"
+    parameter.parameter5options=["0":"Red","21":"Orange","42":"Yellow","85":"Green","127":"Cyan","170":"Blue","212":"Violet","234":"Pink"]
+    parameter.parameter6options=["0":"0%","1":"10%","2":"20%","3":"30%","4":"40%","5":"50%","6":"60%","7":"70%","8":"80%","9":"90%","10":"100%"]
+    parameter.parameter7options=["0":"0%","1":"10%","2":"20%","3":"30%","4":"40%","5":"50%","6":"60%","7":"70%","8":"80%","9":"90%","10":"100%"]
+    parameter.parameter8options=["1":"Yes", "2":"No"]
+    parameter.parameter9options=["0":"Stay Off","1":"1 Second","2":"2 Seconds","3":"3 Seconds","4":"4 Seconds","5":"5 Seconds","6":"6 Seconds","7":"7 Seconds","8":"8 Seconds","9":"9 Seconds","10":"10 Seconds"]
+    parameter.parameter10options="0..100"
+    parameter.parameter11options="0..32767"
+    parameter.parameter12options="0..100"
+    
+    parameter.parameter1name="State After Power Restored"
+    parameter.parameter2name="Invert Switch"
+    parameter.parameter3name="Auto Off Timer"
+    parameter.parameter4name="Association Behavior"
+    parameter.parameter5name="LED Strip Color"
+    parameter.parameter6name="LED Strip Intensity"
+    parameter.parameter7name="LED Strip Intensity (When OFF)"
+    parameter.parameter8name="LED Strip Effect"
+    parameter.parameter9name="LED Strip Timeout"
+    parameter.parameter10name="Active Power Reports"
+    parameter.parameter11name="Periodic Power & Energy Reports"
+    parameter.parameter12name="Energy Reports"
+    
+    parameter.parameter1description="The state the switch should return to once power is restored after power failure."
+	parameter.parameter2description="Inverts the orientation of the switch. Useful when the switch is installed upside down. Essentially up becomes down and down becomes up."
+    parameter.parameter3description="Automatically turns the switch off after this many seconds. When the switch is turned on a timer is started that is the duration of this setting. When the timer expires, the switch is turned off."
+    parameter.parameter4description="When should the switch send commands to associated devices?\n\n01 - local\n02 - 3way\n03 - 3way & local\n04 - z-wave hub\n05 - z-wave hub & local\n06 - z-wave hub & 3-way\n07 - z-wave hub & local & 3way\n08 - timer\n09 - timer & local\n10 - timer & 3-way\n11 - timer & 3-way & local\n12 - timer & z-wave hub\n13 - timer & z-wave hub & local\n14 - timer & z-wave hub & 3-way\n15 - all"
+    parameter.parameter5description="This is the color of the LED strip."
+    parameter.parameter6description="This is the intensity of the LED strip."
+    parameter.parameter7description="This is the intensity of the LED strip when the switch is off. This is useful for users to see the light switch location when the lights are off."
+    parameter.parameter8description="LED Strip Effect"
+    parameter.parameter9description="When the LED strip is disabled (LED Strip Intensity is set to 0), this setting allows the LED strip to turn on temporarily while being adjusted."
+    parameter.parameter10description="The power level change that will result in a new power report being sent. The value is a percentage of the previous report. 0 = disabled."
+    parameter.parameter11description="Time period between consecutive power & energy reports being sent (in seconds). The timer is reset after each report is sent."
+    parameter.parameter12description="The energy level change that will result in a new energy report being sent. The value is a percentage of the previous report."
+    
+    return parameter."parameter${number}${type}"
+}
+
+def zwaveEvent(hubitat.zwave.commands.configurationv1.ConfigurationReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: ${device.displayName} parameter '${cmd.parameterNumber}' with a byte size of '${cmd.size}' is set to '${cmd2Integer(cmd.configurationValue)}'"
+    state."parameter${cmd.parameterNumber}value" = cmd2Integer(cmd.configurationValue)
+}
+
+def cmd2Integer(array) {
+    switch(array.size()) {
+        case 1:
+            array[0]
+            break
+        case 2:
+            ((array[0] & 0xFF) << 8) | (array[1] & 0xFF)
+            break
+        case 3:
+            ((array[0] & 0xFF) << 16) | ((array[1] & 0xFF) << 8) | (array[2] & 0xFF)
+            break
+        case 4:
+            ((array[0] & 0xFF) << 24) | ((array[1] & 0xFF) << 16) | ((array[2] & 0xFF) << 8) | (array[3] & 0xFF)
+            break
+    }
+}
+
+def integer2Cmd(value, size) {
+    try{
+	switch(size) {
+	case 1:
+		[value]
+    break
+	case 2:
+    	def short value1   = value & 0xFF
+        def short value2 = (value >> 8) & 0xFF
+        [value2, value1]
+    break
+    case 3:
+    	def short value1   = value & 0xFF
+        def short value2 = (value >> 8) & 0xFF
+        def short value3 = (value >> 16) & 0xFF
+        [value3, value2, value1]
+    break
+	case 4:
+    	def short value1 = value & 0xFF
+        def short value2 = (value >> 8) & 0xFF
+        def short value3 = (value >> 16) & 0xFF
+        def short value4 = (value >> 24) & 0xFF
+		[value4, value3, value2, value1]
+	break
+	}
+    } catch (e) {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Error: integer2Cmd $e Value: $value"
+    }
+}
+
+private getCommandClassVersions() {
+	[0x20: 1, 0x25: 1, 0x70: 1, 0x98: 1, 0x32: 3]
+}
+
+def zwaveEvent(hubitat.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
+    def encapsulatedCommand = cmd.encapsulatedCommand(commandClassVersions)
+    if (encapsulatedCommand) {
+        state.sec = 1
+        zwaveEvent(encapsulatedCommand)
+    }
+}
+
+def parse(description) {
+    def result = null
+    if (description.startsWith("Err 106")) {
+        state.sec = 0
+        result = createEvent(descriptionText: description, isStateChange: true)
+    } else if (description != "updated") {
+        def cmd = zwave.parse(description, commandClassVersions)
+        if (cmd) {
+            result = zwaveEvent(cmd)
+            //if (debugEnable) log.debug("'$cmd' parsed to $result")
+        } else {
+            if (debugEnable) log.debug("Couldn't zwave.parse '$description'")
+        }
+    }
+    def now
+    if(location.timeZone)
+    now = new Date().format("yyyy MMM dd EEE h:mm:ss a", location.timeZone)
+    else
+    now = new Date().format("yyyy MMM dd EEE h:mm:ss a")
+    sendEvent(name: "lastActivity", value: now, displayed:false)
+    result
+}
+
+def zwaveEvent(hubitat.zwave.commands.basicv1.BasicReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Basic report received with value of ${cmd.value ? "on" : "off"}"
+	createEvent(name: "switch", value: cmd.value ? "on" : "off", type: "physical")
+}
+
+def zwaveEvent(hubitat.zwave.commands.basicv1.BasicSet cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Basic set received with value of ${cmd.value ? "on" : "off"}"
+	createEvent(name: "switch", value: cmd.value ? "on" : "off", type: "physical")
+}
+
+def zwaveEvent(hubitat.zwave.commands.switchbinaryv1.SwitchBinaryReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Switch Binary report received with value of ${cmd.value ? "on" : "off"}"
+	createEvent(name: "switch", value: cmd.value ? "on" : "off", type: "digital")
+}
+
+def zwaveEvent(hubitat.zwave.Command cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: Unhandled: $cmd"
+    null
+}
+
+def on() {
+    commands([
+        zwave.basicV1.basicSet(value: 0xFF)//,
+        //zwave.basicV1.basicGet()
+    ])
+}
+
+def off() {
+    commands([
+        zwave.basicV1.basicSet(value: 0x00)//,
+        //zwave.basicV1.basicGet()
+    ])
+}
+
+def ping() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: ping()"
+    //refresh()
+}
+
+def poll() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: poll()"
+    //refresh()
+}
+
+def refresh() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: refresh()"
+    def cmds = []
+    cmds << zwave.basicV1.basicGet()
+    cmds << zwave.meterV3.meterGet(scale: 0)
+	cmds << zwave.meterV3.meterGet(scale: 2)
+    cmds << zwave.protectionV2.protectionGet()
+    return commands(cmds)
+}
+
+private command(hubitat.zwave.Command cmd) {
+    if (state.sec) {
+        zwave.securityV1.securityMessageEncapsulation().encapsulate(cmd).format()
+    } else {
+        cmd.format()
+    }
+}
+
+private commands(commands, delay=500) {
+    delayBetween(commands.collect{ command(it) }, delay)
+}
+
+def setDefaultAssociations() {
+    def smartThingsHubID = String.format('%02x', zwaveHubNodeId).toUpperCase()
+    state.defaultG1 = [smartThingsHubID]
+    state.defaultG2 = []
+    state.defaultG3 = []
+}
+
+def setAssociationGroup(group, node, action, endpoint = null){
+    if (! node =~ /[0-9A-F]+/)
+        return
+
+    if (group < 1 || group > maxAssociationGroup())
+        return
+    
+    def associations = state."desiredAssociation${group}"?:[]
+    switch (action) {
+        case "Remove":
+        associations = associations - node
+        break
+        case "Add":
+        associations << node
+        break
+    }
+    state."desiredAssociation${group}" = associations.unique()
+    return
+}
+
+def maxAssociationGroup(){
+   if (!state.associationGroups) {
+       if (logEnable) log.debug "Getting supported association groups from device"
+       zwave.associationV2.associationGroupingsGet() // execute the update immediately
+   }
+   (state.associationGroups?: 5) as int
+}
+
+def processAssociations(){
+   def cmds = []
+   setDefaultAssociations()
+   def associationGroups = maxAssociationGroup()
+   for (int i = 1; i <= associationGroups; i++){
+      if(state."actualAssociation${i}" != null){
+         if(state."desiredAssociation${i}" != null || state."defaultG${i}") {
+            def refreshGroup = false
+            ((state."desiredAssociation${i}"? state."desiredAssociation${i}" : [] + state."defaultG${i}") - state."actualAssociation${i}").each {
+                if (logEnable) log.debug "Adding node $it to group $i"
+                cmds << zwave.associationV2.associationSet(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
+                refreshGroup = true
+            }
+            ((state."actualAssociation${i}" - state."defaultG${i}") - state."desiredAssociation${i}").each {
+                if (logEnable) log.debug "Removing node $it from group $i"
+                cmds << zwave.associationV2.associationRemove(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
+                refreshGroup = true
+            }
+            if (refreshGroup == true) cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
+            else if (logEnable) log.debug "There are no association actions to complete for group $i"
+         }
+      } else {
+         if (logEnable) log.debug "Association info not known for group $i. Requesting info from device."
+         cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
+      }
+   }
+   return cmds
+}
+
+
+def zwaveEvent(hubitat.zwave.commands.associationv2.AssociationReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${device.label?device.label:device.name}: ${cmd}"
+    def temp = []
+    if (cmd.nodeId != []) {
+       cmd.nodeId.each {
+          temp += it.toString().format( '%02x', it.toInteger() ).toUpperCase()
+       }
+    } 
+    state."actualAssociation${cmd.groupingIdentifier}" = temp
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Associations for Group ${cmd.groupingIdentifier}: ${temp}"
+    updateDataValue("associationGroup${cmd.groupingIdentifier}", "$temp")
+}
+
+def zwaveEvent(hubitat.zwave.commands.associationv2.AssociationGroupingsReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${device.label?device.label:device.name}: ${cmd}"
+    sendEvent(name: "groups", value: cmd.supportedGroupings)
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Supported association groups: ${cmd.supportedGroupings}"
+    state.associationGroups = cmd.supportedGroupings
+}
+
+def zwaveEvent(hubitat.zwave.commands.versionv1.VersionReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${device.label?device.label:device.name}: ${cmd}"
+    if(cmd.applicationVersion != null && cmd.applicationSubVersion != null) {
+	    def firmware = "${cmd.applicationVersion}.${cmd.applicationSubVersion.toString().padLeft(2,'0')}"
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Firmware report received: ${firmware}"
+        state.needfwUpdate = "false"
+        createEvent(name: "firmware", value: "${firmware}")
+    }
+}
+
+def zwaveEvent(hubitat.zwave.commands.protectionv2.ProtectionReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Protection report received: Local protection is ${cmd.localProtectionState > 0 ? "on" : "off"} & Remote protection is ${cmd.rfProtectionState > 0 ? "on" : "off"}"
+    state.localProtectionState = cmd.localProtectionState
+    state.rfProtectionState = cmd.rfProtectionState
+    //device.updateSetting("disableLocal",[value:cmd.localProtectionState?cmd.localProtectionState:0,type:"enum"])
+    //device.updateSetting("disableRemote",[value:cmd.rfProtectionState?cmd.rfProtectionState:0,type:"enum"])
+    def children = childDevices
+    def childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
+    if (childDevice) {
+        childDevice.sendEvent(name: "switch", value: cmd.localProtectionState > 0 ? "on" : "off")        
+    }
+    childDevice = children.find{it.deviceNetworkId.endsWith("ep102")}
+    if (childDevice) {
+        childDevice.sendEvent(name: "switch", value: cmd.rfProtectionState > 0 ? "on" : "off")        
+    }
+}

--- a/Drivers/inovelli-switch-nzw30-w-scene.src/inovelli-switch-nzw30-w-scene.groovy
+++ b/Drivers/inovelli-switch-nzw30-w-scene.src/inovelli-switch-nzw30-w-scene.groovy
@@ -571,21 +571,35 @@ def setDefaultAssociations() {
     state.defaultG3 = []
 }
 
-def setAssociationGroup(group, node, action, endpoint = null){
-    if (! node =~ /[0-9A-F]+/)
-        return
+def setAssociationGroup(group, nodes, action, endpoint = null){
+    // Normalize the arguments to be backwards compatible with the old method
+    action = "${action}" == "1" ? "Add" : "${action}" == "0" ? "Remove" : "${action}" // convert 1/0 to Add/Remove
+    group  = "${group}" =~ /\d+/ ? (group as int) : group                             // convert group to int (if possible)
+    nodes  = [] + nodes ?: [nodes]                                                    // convert to collection if not already a collection
 
-    if (group < 1 || group > maxAssociationGroup())
+    if (! nodes.every { it =~ /[0-9A-F]+/ }) {
+        log.error "invalid Nodes ${nodes}"
         return
+    }
+
+    if (group < 1 || group > maxAssociationGroup()) {
+        log.error "Association group is invalid 1 <= ${group} <= ${maxAssociationGroup()}"
+        return
+    }
     
     def associations = state."desiredAssociation${group}"?:[]
-    switch (action) {
-        case "Remove":
-        associations = associations - node
-        break
-        case "Add":
-        associations << node
-        break
+    nodes.each { 
+        node = "${it}"
+        switch (action) {
+            case "Remove":
+            if (logEnable) log.debug "Removing node ${node} from association group ${group}"
+            associations = associations - node
+            break
+            case "Add":
+            if (logEnable) log.debug "Adding node ${node} to association group ${group}"
+            associations << node
+            break
+        }
     }
     state."desiredAssociation${group}" = associations.unique()
     return

--- a/Drivers/inovelli-switch-nzw30-w-scene.src/inovelli-switch-nzw30-w-scene.groovy
+++ b/Drivers/inovelli-switch-nzw30-w-scene.src/inovelli-switch-nzw30-w-scene.groovy
@@ -1,7 +1,4 @@
 /**
- *
- *  Hubitat Import URL: https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-switch-nzw30-w-scene.src/inovelli-switch-nzw30-w-scene.groovy
- *
  *  Inovelli Switch NZW30/NZW30T w/Scene
  *  Author: Eric Maycock (erocm123)
  *  Date: 2018-12-04
@@ -16,6 +13,8 @@
  *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
+ *
+ *  2019-11-20: Fixed Association Group management.
  *
  *  2018-12-04: Added option to "Disable Remote Control" and to send button events 1,pushed / 1,held for on / off.
  *
@@ -38,7 +37,13 @@
  */
  
 metadata {
-	definition (name: "Inovelli Switch NZW30 w/Scene", namespace: "InovelliUSA", author: "Eric Maycock", vid: "generic-switch") {
+	definition (
+        name: "Inovelli Switch NZW30 w/Scene", 
+        namespace: "InovelliUSA", 
+        author: "Eric Maycock", 
+        vid: "generic-switch",
+        importUrl: "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-switch-nzw30-w-scene.src/inovelli-switch-nzw30-w-scene.groovy"
+    ) {
 		capability "Switch"
 		capability "Refresh"
 		capability "Polling"
@@ -66,7 +71,11 @@ metadata {
         command "holdUp"
         command "holdDown"
         
-        command "setAssociationGroup", ["number", "enum", "number", "number"] // group number, nodes, action (0 - remove, 1 - add), multi-channel endpoint (optional)
+        command "setAssociationGroup", [[name: "Group Number*",type:"NUMBER", description: "Provide the association group number to edit"], 
+                                        [name: "Z-Wave Node*", type:"STRING", description: "Enter the node number (in hex) associated with the node"], 
+                                        [name: "Action*", type:"ENUM", constraints: ["Add", "Remove"]],
+                                        [name:"Multi-channel Endpoint", type:"NUMBER", description: "Currently not implemented"]] 
+
         command "childOn"
         command "childOff"
         command "childRefresh"
@@ -556,55 +565,63 @@ def holdDown() {
 }
 
 def setDefaultAssociations() {
-    def smartThingsHubID = zwaveHubNodeId.toString().format( '%02x', zwaveHubNodeId )
+    def smartThingsHubID = String.format('%02x', zwaveHubNodeId).toUpperCase()
     state.defaultG1 = [smartThingsHubID]
     state.defaultG2 = []
+    state.defaultG3 = []
 }
 
-def setAssociationGroup(group, nodes, action, endpoint = null){
-    if (!state."desiredAssociation${group}") {
-        state."desiredAssociation${group}" = nodes
-    } else {
-        switch (action) {
-            case 0:
-                state."desiredAssociation${group}" = state."desiredAssociation${group}" - nodes
-            break
-            case 1:
-                state."desiredAssociation${group}" = state."desiredAssociation${group}" + nodes
-            break
-        }
+def setAssociationGroup(group, node, action, endpoint = null){
+    if (! node =~ /[0-9A-F]+/)
+        return
+
+    if (group < 1 || group > maxAssociationGroup())
+        return
+    
+    def associations = state."desiredAssociation${group}"?:[]
+    switch (action) {
+        case "Remove":
+        associations = associations - node
+        break
+        case "Add":
+        associations << node
+        break
     }
+    state."desiredAssociation${group}" = associations.unique()
+    return
+}
+
+def maxAssociationGroup(){
+   if (!state.associationGroups) {
+       if (logEnable) log.debug "Getting supported association groups from device"
+       zwave.associationV2.associationGroupingsGet() // execute the update immediately
+   }
+   (state.associationGroups?: 5) as int
 }
 
 def processAssociations(){
    def cmds = []
    setDefaultAssociations()
-   def associationGroups = 5
-   if (state.associationGroups) {
-       associationGroups = state.associationGroups
-   } else {
-       log.debug "Getting supported association groups from device"
-       cmds <<  zwave.associationV2.associationGroupingsGet()
-   }
+   def associationGroups = maxAssociationGroup()
    for (int i = 1; i <= associationGroups; i++){
       if(state."actualAssociation${i}" != null){
          if(state."desiredAssociation${i}" != null || state."defaultG${i}") {
             def refreshGroup = false
             ((state."desiredAssociation${i}"? state."desiredAssociation${i}" : [] + state."defaultG${i}") - state."actualAssociation${i}").each {
-                log.debug "Adding node $it to group $i"
-                cmds << zwave.associationV2.associationSet(groupingIdentifier:i, nodeId:Integer.parseInt(it,16))
+                if (logEnable) log.debug "Adding node $it to group $i"
+                cmds << zwave.associationV2.associationSet(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
                 refreshGroup = true
             }
             ((state."actualAssociation${i}" - state."defaultG${i}") - state."desiredAssociation${i}").each {
-                log.debug "Removing node $it from group $i"
-                cmds << zwave.associationV2.associationRemove(groupingIdentifier:i, nodeId:Integer.parseInt(it,16))
+                if (logEnable) log.debug "Removing node $it from group $i"
+                cmds << zwave.associationV2.associationRemove(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
                 refreshGroup = true
             }
             if (refreshGroup == true) cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
-            else log.debug "There are no association actions to complete for group $i"
+            else if (logEnable) log.debug "There are no association actions to complete for group $i"
          }
       } else {
-         log.debug "Association info not known for group $i. Requesting info from device."
+         if (logEnable) log.debug "Association info not known for group $i. Requesting info from device."
          cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
       }
    }

--- a/Drivers/inovelli-switch-nzw30.src/inovelli-switch-nzw30.groovy
+++ b/Drivers/inovelli-switch-nzw30.src/inovelli-switch-nzw30.groovy
@@ -363,21 +363,35 @@ def setDefaultAssociations() {
     state.defaultG3 = []
 }
 
-def setAssociationGroup(group, node, action, endpoint = null){
-    if (! node =~ /[0-9A-F]+/)
-        return
+def setAssociationGroup(group, nodes, action, endpoint = null){
+    // Normalize the arguments to be backwards compatible with the old method
+    action = "${action}" == "1" ? "Add" : "${action}" == "0" ? "Remove" : "${action}" // convert 1/0 to Add/Remove
+    group  = "${group}" =~ /\d+/ ? (group as int) : group                             // convert group to int (if possible)
+    nodes  = [] + nodes ?: [nodes]                                                    // convert to collection if not already a collection
 
-    if (group < 1 || group > maxAssociationGroup())
+    if (! nodes.every { it =~ /[0-9A-F]+/ }) {
+        log.error "invalid Nodes ${nodes}"
         return
+    }
+
+    if (group < 1 || group > maxAssociationGroup()) {
+        log.error "Association group is invalid 1 <= ${group} <= ${maxAssociationGroup()}"
+        return
+    }
     
     def associations = state."desiredAssociation${group}"?:[]
-    switch (action) {
-        case "Remove":
-        associations = associations - node
-        break
-        case "Add":
-        associations << node
-        break
+    nodes.each { 
+        node = "${it}"
+        switch (action) {
+            case "Remove":
+            if (logEnable) log.debug "Removing node ${node} from association group ${group}"
+            associations = associations - node
+            break
+            case "Add":
+            if (logEnable) log.debug "Adding node ${node} to association group ${group}"
+            associations << node
+            break
+        }
     }
     state."desiredAssociation${group}" = associations.unique()
     return

--- a/Drivers/inovelli-switch-red-series-lzw30-sn.src/inovelli-switch-red-series-lzw30-sn.groovy
+++ b/Drivers/inovelli-switch-red-series-lzw30-sn.src/inovelli-switch-red-series-lzw30-sn.groovy
@@ -1,0 +1,889 @@
+/**
+ *  Inovelli Switch Red Series
+ *  Author: Eric Maycock (erocm123)
+ *  Date: 2019-10-15
+ *
+ *  Copyright 2019 Eric Maycock / Inovelli
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ *  2019-11-20: Fixed Association Group management.
+ *
+ *  2019-10-15: Ability to create child devices for local & rf protection to use in various automations.
+ *              Device label is now displayed in logging. 
+ * 
+ *  2019-10-01: Adding the ability to set a custom color for the RGB indicator. Use a hue 360 color wheel.
+ *              Adding the ability to enable z-wave "rf protection" to disable control from z-wave commands.
+ *
+ */
+ 
+metadata {
+    definition (name: "Inovelli Switch Red Series LZW30-SN", namespace: "InovelliUSA", author: "Eric Maycock", vid: "generic-switch", importUrl: "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-switch-red-series-lzw30-sn.src/inovelli-switch-red-series-lzw30-sn.groovy") {
+        capability "Switch"
+        capability "Refresh"
+        capability "Actuator"
+        capability "Sensor"
+        capability "PushableButton"
+        capability "HoldableButton"
+        capability "Configuration"
+        capability "Energy Meter"
+        capability "Power Meter"
+        
+        attribute "lastActivity", "String"
+        attribute "lastEvent", "String"
+        attribute "firmware", "String"
+        
+        command "pressUpX1"
+        command "pressDownX1"
+        command "pressUpX2"
+        command "pressDownX2"
+        command "pressUpX3"
+        command "pressDownX3"
+        command "pressUpX4"
+        command "pressDownX4"
+        command "pressUpX5"
+        command "pressDownX5"
+        command "holdUp"
+        command "holdDown"
+        command "pressConfig"
+        
+        command "childOn"
+        command "childOff"
+        command "childRefresh"
+        command "reset"
+        
+        command "setAssociationGroup", [[name: "Group Number*",type:"NUMBER", description: "Provide the association group number to edit"], 
+                                        [name: "Z-Wave Node*", type:"STRING", description: "Enter the node number (in hex) associated with the node"], 
+                                        [name: "Action*", type:"ENUM", constraints: ["Add", "Remove"]],
+                                        [name:"Multi-channel Endpoint", type:"NUMBER", description: "Currently not implemented"]] 
+
+        fingerprint mfr: "031E", prod: "0002", model: "0001", deviceJoinName: "Inovelli Switch Red Series" 
+        fingerprint deviceId: "0x1001", inClusters: "0x5E,0x6C,0x55,0x98,0x9F,0x22,0x70,0x85,0x59,0x86,0x32,0x72,0x5A,0x5B,0x73,0x75,0x7A"
+        fingerprint deviceId: "0x1001", inClusters: "0x5E,0x70,0x85,0x59,0x55,0x86,0x72,0x5A,0x73,0x32,0x5B,0x98,0x9F,0x25,0x6C,0x75,0x22,0x7A"
+        
+    }
+
+    simulator {
+    }
+    
+    preferences {
+        generate_preferences()
+    }
+}
+
+def generate_preferences()
+{
+    getParameterNumbers().each { i ->
+        
+        switch(getParameterInfo(i, "type"))
+        {   
+            case "number":
+                input "parameter${i}", "number",
+                    title:getParameterInfo(i, "name") + "\n" + getParameterInfo(i, "description") + "\nRange: " + getParameterInfo(i, "options") + "\nDefault: " + getParameterInfo(i, "default"),
+                    range: getParameterInfo(i, "options")
+                    //defaultValue: getParameterInfo(i, "default")
+            break
+            case "enum":
+                input "parameter${i}", "enum",
+                    title:getParameterInfo(i, "name") + "\n" + getParameterInfo(i, "description"), 
+                    //defaultValue: getParameterInfo(i, "default"),
+                    options: getParameterInfo(i, "options")
+            break
+        }
+        if (i == 5){
+           input "parameter5custom", "number", 
+               title: "Custom LED RGB Value", 
+               description: "\nInput a custom value in this field to override the above setting. The value should be between 0 - 360 and can be determined by using the typical hue color wheel.", 
+               required: false,
+               range: "0..360"
+        }
+    }
+    
+    input description: "When each notification set (Color, Level, Duration, Type) is configured, a switch child device is created that can be used in SmartApps to activate that notification.", title: "LED Notifications", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+    
+    [1,2,3,4,5].each { i ->
+                input "parameter8-${i}a", "enum", title: "LED Effect Color - Notification $i", description: "Tap to set", displayDuringSetup: false, required: false, options: [
+                    0:"Red",
+                    21:"Orange",
+                    42:"Yellow",
+                    85:"Green",
+                    127:"Cyan",
+                    170:"Blue",
+                    212:"Violet",
+                    234:"Pink"]
+                input "parameter8-${i}b", "enum", title: "LED Effect Level - Notification $i", description: "Tap to set", displayDuringSetup: false, required: false, options: [
+                    0:"0%",
+                    1:"10%",
+                    2:"20%",
+                    3:"30%",
+                    4:"40%",
+                    5:"50%",
+                    6:"60%",
+                    7:"70%",
+                    8:"80%",
+                    9:"90%",
+                    10:"100%"]
+                input "parameter8-${i}c", "enum", title: "LED Effect Duration - Notification $i", description: "Tap to set", displayDuringSetup: false, required: false, options: [
+                    1:"1 Second",
+                    2:"2 Seconds",
+                    3:"3 Seconds",
+                    4:"4 Seconds",
+                    5:"5 Seconds",
+                    6:"6 Seconds",
+                    7:"7 Seconds",
+                    8:"8 Seconds",
+                    9:"9 Seconds",
+                    10:"10 Seconds",
+                    20:"20 Seconds",
+                    30:"30 Seconds",
+                    40:"40 Seconds",
+                    50:"50 Seconds",
+                    60:"60 Seconds",
+                    62:"2 Minutes",
+                    63:"3 Minutes",
+                    64:"4 Minutes",
+                    65:"5 Minutes",
+                    255:"Indefinetly"]
+                input "parameter8-${i}d", "enum", title: "LED Effect Type - Notification $i", description: "Tap to set", displayDuringSetup: false, required: false, options: [
+                    0:"Off",
+                    1:"Solid",
+                    //2:"Chase",
+                    2:"Fast Blink",
+                    3:"Slow Blink",
+                    4:"Pulse"]
+    
+    }
+    input "disableLocal", "enum", title: "Disable Local Control", description: "\nDisable ability to control switch from the wall", required: false, options:[["1": "Yes"], ["0": "No"]], defaultValue: "0"
+    input "disableRemote", "enum", title: "Disable Remote Control", description: "\nDisable ability to control switch from inside SmartThings", required: false, options:[["1": "Yes"], ["0": "No"]], defaultValue: "0"
+    input description: "Use the below options to enable child devices for the specified settings. This will allow you to adjust these settings using SmartApps such as Smart Lighting. If any of the options are enabled, make sure you have the appropriate child device handlers installed.\n(Firmware 1.02+)", title: "Child Devices", displayDuringSetup: false, type: "paragraph", element: "paragraph"
+    input "enableDisableLocalChild", "bool", title: "Disable Local Control", description: "", required: false, defaultValue: false
+    input "enableDisableRemoteChild", "bool", title: "Disable Remote Control", description: "", required: false, defaultValue: false
+    input name: "debugEnable", type: "bool", title: "Enable debug logging", defaultValue: true
+    input name: "infoEnable", type: "bool", title: "Enable informational logging", defaultValue: true
+}
+
+private channelNumber(String dni) {
+    dni.split("-ep")[-1] as Integer
+}
+
+private sendAlert(data) {
+    sendEvent(
+        descriptionText: data.message,
+        eventType: "ALERT",
+        name: "failedOperation",
+        value: "failed",
+        displayed: true,
+    )
+}
+
+def childSetLevel(String dni, value) {
+    def valueaux = value as Integer
+    def level = Math.max(Math.min(valueaux, 99), 0)    
+    def cmds = []
+    switch (channelNumber(dni)) {
+        case 101:
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionSet(localProtectionState : level > 0 ? 1 : 0, rfProtectionState: state.rfProtectionState? state.rfProtectionState:0) ), hubitat.device.Protocol.ZWAVE)
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionGet() ), hubitat.device.Protocol.ZWAVE)
+        break
+        case 102:
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionSet(localProtectionState : state.localProtectionState? state.localProtectionState:0, rfProtectionState : level > 0 ? 1 : 0) ), hubitat.device.Protocol.ZWAVE)
+            cmds << new hubitat.device.HubAction(command(zwave.protectionV2.protectionGet() ), hubitat.device.Protocol.ZWAVE)
+        break
+    }
+	return cmds
+}
+
+private toggleTiles(number, value) {
+   for (int i = 1; i <= 5; i++){
+       if ("${i}" != number){
+           def childDevice = childDevices.find{it.deviceNetworkId == "$device.deviceNetworkId-ep$i"}
+           if (childDevice) {         
+                childDevice.sendEvent(name: "switch", value: "off")
+           }
+       } else {
+           def childDevice = childDevices.find{it.deviceNetworkId == "$device.deviceNetworkId-ep$i"}
+           if (childDevice) {         
+                childDevice.sendEvent(name: "switch", value: value)
+           }
+       }
+   }
+}
+
+def childOn(String dni) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: childOn($dni)"
+    def cmds = []
+    if(channelNumber(dni).toInteger() <= 5) {
+        toggleTiles("${channelNumber(dni)}", "on")
+        cmds << new hubitat.device.HubAction(command(setParameter(8, calculateParameter("8-${channelNumber(dni)}"), 4)), hubitat.device.Protocol.ZWAVE )
+        return cmds
+    } else {
+        childSetLevel(dni, 99)
+    }
+}
+
+def childOff(String dni) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: childOff($dni)"
+    def cmds = []
+    if(channelNumber(dni).toInteger() <= 5) {
+        toggleTiles("${channelNumber(dni)}", "off")
+        cmds << new hubitat.device.HubAction(command(setParameter(8, 0, 4)), hubitat.device.Protocol.ZWAVE )
+        return cmds
+    } else {
+        childSetLevel(dni, 0)
+    }
+}
+
+void childRefresh(String dni) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: childRefresh($dni)"
+}
+
+def childExists(ep) {
+    def children = childDevices
+    def childDevice = children.find{it.deviceNetworkId.endsWith(ep)}
+    if (childDevice) 
+        return true
+    else
+        return false
+}
+
+def installed() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: installed()"
+    refresh()
+}
+
+def configure() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: configure()"
+    def cmds = initialize()
+    commands(cmds)
+}
+
+def updated() {
+    if (!state.lastRan || now() >= state.lastRan + 2000) {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: updated()"
+        state.lastRan = now()
+        def cmds = initialize()
+        if (cmds != [])
+            commands(cmds, 1000)
+        else 
+            return null
+    } else {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: updated() ran within the last 2 seconds. Skipping execution."
+    }
+}
+
+def initialize() {
+    sendEvent(name: "checkInterval", value: 3 * 60 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID, offlinePingable: "1"])
+    sendEvent(name: "numberOfButtons", value: 7, displayed: true)
+    
+    if (enableDisableLocalChild && !childExists("ep101")) {
+    try {
+        addChildDevice("Switch Level Child Device", "${device.deviceNetworkId}-ep101",
+                [completedSetup: true, label: "${device.displayName} (Disable Local Control)",
+                isComponent: true, componentName: "ep101", componentLabel: "Disable Local Control"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
+    }
+    } else if (!enableDisableLocalChild && childExists("ep101")) {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Trying to delete child device ep101. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
+        try {
+            if (infoEnable) log.info "${device.label?device.label:device.name}: SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }
+    if (enableDisableRemoteChild && !childExists("ep102")) {
+    try {
+        addChildDevice("Switch Level Child Device", "${device.deviceNetworkId}-ep102", 
+                [completedSetup: true, label: "${device.displayName} (Disable Remote Control)",
+                isComponent: true, componentName: "ep102", componentLabel: "Disable Remote Control"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Level Child Device\" is installed"]])
+    }
+    } else if (!enableDisableRemoteChild && childExists("ep102")) {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Trying to delete child device ep101. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep102")}
+        try {
+            if (infoEnable) log.info "${device.label?device.label:device.name}: SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }
+    
+    [1,2,3,4,5].each { i ->
+    if ((settings."parameter8-${i}a"!=null && settings."parameter8-${i}b"!=null && settings."parameter8-${i}c"!=null && settings."parameter8-${i}d"!=null) && !childExists("ep${i}")) {
+    try {
+        addChildDevice("Switch Child Device", "${device.deviceNetworkId}-ep${i}",
+                [completedSetup: true, label: "${device.displayName} (Notification ${i})",
+                isComponent: true, componentName: "ep${i}", componentLabel: "Notification ${i}"])
+    } catch (e) {
+        runIn(3, "sendAlert", [data: [message: "Child device creation failed. Make sure the device handler for \"Switch Child Device\" is installed"]])
+    }
+    } else if ((settings."parameter8-${i}a"==null || settings."parameter8-${i}b"==null || settings."parameter8-${i}c"==null || settings."parameter8-${i}d"==null) && childExists("ep${i}")) {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Trying to delete child device ep${i}. If this fails it is likely that there is a SmartApp using the child device in question."
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep${i}")}
+        try {
+            if (infoEnable) log.info "${device.label?device.label:device.name}: SmartThings has issues trying to delete the child device when it is in use. Need to manually delete them."
+            //if(childDevice) deleteChildDevice(childDevice.deviceNetworkId)
+        } catch (e) {
+            runIn(3, "sendAlert", [data: [message: "Failed to delete child device. Make sure the device is not in use by any SmartApp."]])
+        }
+    }}
+    if (device.label != state.oldLabel) {
+        def children = childDevices
+        def childDevice = children.find{it.deviceNetworkId.endsWith("ep1")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Notification 1)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep2")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Notification 2)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep3")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Notification 3)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep4")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Notification 4)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Disable Local Control)")
+        childDevice = children.find{it.deviceNetworkId.endsWith("ep102")}
+        if (childDevice)
+        childDevice.setLabel("${device.displayName} (Disable Remote Control)")
+        state.oldLabel = device.label
+    }
+    
+    def cmds = processAssociations()
+    
+    getParameterNumbers().each{ i ->
+      if ((state."parameter${i}value" != ((settings."parameter${i}"!=null||calculateParameter(i)!=null)? calculateParameter(i).toInteger() : getParameterInfo(i, "default").toInteger()))){
+          cmds << setParameter(i, (settings."parameter${i}"!=null||calculateParameter(i)!=null)? calculateParameter(i).toInteger() : getParameterInfo(i, "default").toInteger(), getParameterInfo(i, "size").toInteger())
+          cmds << getParameter(i)
+      }
+      else {
+          //if (infoEnable) log.info "${device.label?device.label:device.name}: Parameter already set"
+      }
+    }
+    
+    cmds << zwave.versionV1.versionGet()
+    
+    if (state.localProtectionState != settings.disableLocal || state.rfProtectionState != settings.disableRemote) {
+        cmds << zwave.protectionV2.protectionSet(localProtectionState : disableLocal!=null? disableLocal.toInteger() : 0, rfProtectionState: disableRemote!=null? disableRemote.toInteger() : 0)
+        cmds << zwave.protectionV2.protectionGet()
+    }
+
+    if (cmds != []) return cmds else return []
+}
+
+def calculateParameter(number) {
+    def value = 0
+    switch (number){
+      case "5":
+          if (settings.parameter5custom =~ /^([0-9]{1}|[0-9]{2}|[0-9]{3})$/) value = settings.parameter5custom.toInteger() / 360 * 255
+          else value = settings."parameter${number}"
+      break
+      case "8-1":
+      case "8-2":
+      case "8-3": 
+      case "8-4":
+      case "8-5":
+         value += settings."parameter${number}a"!=null ? settings."parameter${number}a".toInteger() * 1 : 0
+         value += settings."parameter${number}b"!=null ? settings."parameter${number}b".toInteger() * 256 : 0
+         value += settings."parameter${number}c"!=null ? settings."parameter${number}c".toInteger() * 65536 : 0
+         value += settings."parameter${number}d"!=null ? settings."parameter${number}d".toInteger() * 16777216 : 0
+      break
+      default:
+          value = settings."parameter${number}"
+      break
+    }
+    return value
+}
+
+def setParameter(number, value, size) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Setting parameter $number with a size of $size bytes to $value"
+    return zwave.configurationV1.configurationSet(configurationValue: integer2Cmd(value.toInteger(),size), parameterNumber: number, size: size)
+}
+
+def getParameter(number) {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Retreiving value of parameter $number"
+    return zwave.configurationV1.configurationGet(parameterNumber: number)
+}
+
+def getParameterNumbers(){
+    return [1,2,3,4,5,6,7,10,11,12]
+}
+
+def getParameterInfo(number, type){
+    def parameter = [:]
+
+    parameter.parameter1default=0
+    parameter.parameter2default=0
+    parameter.parameter3default=0
+    parameter.parameter4default=15
+    parameter.parameter5default=170
+    parameter.parameter6default=5
+    parameter.parameter7default=1
+    parameter.parameter8default=0
+    parameter.parameter9default=0
+    parameter.parameter10default=10
+    parameter.parameter11default=3600
+    parameter.parameter12default=10
+    
+    parameter.parameter1type="enum"
+    parameter.parameter2type="enum"
+    parameter.parameter3type="number"
+    parameter.parameter4type="number"
+    parameter.parameter5type="enum"
+    parameter.parameter6type="enum"
+    parameter.parameter7type="enum"
+    parameter.parameter8type="enum"
+    parameter.parameter9type="enum"
+    parameter.parameter10type="number"
+    parameter.parameter11type="number"
+    parameter.parameter12type="number"
+    
+    parameter.parameter1size=1
+    parameter.parameter2size=1
+    parameter.parameter3size=2
+    parameter.parameter4size=1
+    parameter.parameter5size=2
+    parameter.parameter6size=1
+    parameter.parameter7size=1
+    parameter.parameter8size=4
+    parameter.parameter9size=1
+    parameter.parameter10size=1
+    parameter.parameter11size=2
+    parameter.parameter12size=1
+    
+	parameter.parameter1options=["0":"Previous", "1":"On", "2":"Off"]
+    parameter.parameter2options=["1":"Yes", "0":"No"]
+    parameter.parameter3options="1..32767"
+    parameter.parameter4options="0..15"
+    parameter.parameter5options=["0":"Red","21":"Orange","42":"Yellow","85":"Green","127":"Cyan","170":"Blue","212":"Violet","234":"Pink"]
+    parameter.parameter6options=["0":"0%","1":"10%","2":"20%","3":"30%","4":"40%","5":"50%","6":"60%","7":"70%","8":"80%","9":"90%","10":"100%"]
+    parameter.parameter7options=["0":"0%","1":"10%","2":"20%","3":"30%","4":"40%","5":"50%","6":"60%","7":"70%","8":"80%","9":"90%","10":"100%"]
+    parameter.parameter8options=["1":"Yes", "2":"No"]
+    parameter.parameter9options=["0":"Stay Off","1":"1 Second","2":"2 Seconds","3":"3 Seconds","4":"4 Seconds","5":"5 Seconds","6":"6 Seconds","7":"7 Seconds","8":"8 Seconds","9":"9 Seconds","10":"10 Seconds"]
+    parameter.parameter10options="0..100"
+    parameter.parameter11options="0..32767"
+    parameter.parameter12options="0..100"
+    
+    parameter.parameter1name="State After Power Restored"
+    parameter.parameter2name="Invert Switch"
+    parameter.parameter3name="Auto Off Timer"
+    parameter.parameter4name="Association Behavior"
+    parameter.parameter5name="LED Strip Color"
+    parameter.parameter6name="LED Strip Intensity"
+    parameter.parameter7name="LED Strip Intensity (When OFF)"
+    parameter.parameter8name="LED Strip Effect"
+    parameter.parameter9name="LED Strip Timeout"
+    parameter.parameter10name="Active Power Reports"
+    parameter.parameter11name="Periodic Power & Energy Reports"
+    parameter.parameter12name="Energy Reports"
+    
+    
+    parameter.parameter1description="The state the switch should return to once power is restored after power failure."
+	parameter.parameter2description="Inverts the orientation of the switch. Useful when the switch is installed upside down. Essentially up becomes down and down becomes up."
+    parameter.parameter3description="Automatically turns the switch off after this many seconds. When the switch is turned on a timer is started that is the duration of this setting. When the timer expires, the switch is turned off."
+    parameter.parameter4description="When should the switch send commands to associated devices?\n\n01 - local\n02 - 3way\n03 - 3way & local\n04 - z-wave hub\n05 - z-wave hub & local\n06 - z-wave hub & 3-way\n07 - z-wave hub & local & 3way\n08 - timer\n09 - timer & local\n10 - timer & 3-way\n11 - timer & 3-way & local\n12 - timer & z-wave hub\n13 - timer & z-wave hub & local\n14 - timer & z-wave hub & 3-way\n15 - all"
+    parameter.parameter5description="This is the color of the LED strip."
+    parameter.parameter6description="This is the intensity of the LED strip."
+    parameter.parameter7description="This is the intensity of the LED strip when the switch is off. This is useful for users to see the light switch location when the lights are off."
+    parameter.parameter8description="LED Strip Effect"
+    parameter.parameter9description="When the LED strip is disabled (LED Strip Intensity is set to 0), this setting allows the LED strip to turn on temporarily while being adjusted."
+    parameter.parameter10description="The power level change that will result in a new power report being sent. The value is a percentage of the previous report. 0 = disabled."
+    parameter.parameter11description="Time period between consecutive power & energy reports being sent (in seconds). The timer is reset after each report is sent."
+    parameter.parameter12description="The energy level change that will result in a new energy report being sent. The value is a percentage of the previous report."
+    
+    return parameter."parameter${number}${type}"
+}
+
+def zwaveEvent(hubitat.zwave.commands.meterv3.MeterReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    def event
+	if (cmd.scale == 0) {
+    	if (cmd.meterType == 161) {
+		    event = createEvent(name: "voltage", value: cmd.scaledMeterValue, unit: "V")
+            if (infoEnable) log.info "${device.label?device.label:device.name}: Voltage report received with value of ${cmd.scaledMeterValue} V"
+        } else if (cmd.meterType == 1) {
+        	event = createEvent(name: "energy", value: cmd.scaledMeterValue, unit: "kWh")
+            if (infoEnable) log.info "${device.label?device.label:device.name}: Energy report received with value of ${cmd.scaledMeterValue} kWh"
+        }
+	} else if (cmd.scale == 1) {
+		event = createEvent(name: "amperage", value: cmd.scaledMeterValue, unit: "A")
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Amperage report received with value of ${cmd.scaledMeterValue} A"
+	} else if (cmd.scale == 2) {
+		event = createEvent(name: "power", value: Math.round(cmd.scaledMeterValue), unit: "W")
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Power report received with value of ${cmd.scaledMeterValue} W"
+	}
+
+    return event
+}
+
+def zwaveEvent(hubitat.zwave.commands.configurationv1.ConfigurationReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: ${device.displayName} parameter '${cmd.parameterNumber}' with a byte size of '${cmd.size}' is set to '${cmd2Integer(cmd.configurationValue)}'"
+    state."parameter${cmd.parameterNumber}value" = cmd2Integer(cmd.configurationValue)
+}
+
+def cmd2Integer(array) {
+    switch(array.size()) {
+        case 1:
+            array[0]
+            break
+        case 2:
+            ((array[0] & 0xFF) << 8) | (array[1] & 0xFF)
+            break
+        case 3:
+            ((array[0] & 0xFF) << 16) | ((array[1] & 0xFF) << 8) | (array[2] & 0xFF)
+            break
+        case 4:
+            ((array[0] & 0xFF) << 24) | ((array[1] & 0xFF) << 16) | ((array[2] & 0xFF) << 8) | (array[3] & 0xFF)
+            break
+    }
+}
+
+def integer2Cmd(value, size) {
+    try{
+	switch(size) {
+	case 1:
+		[value]
+    break
+	case 2:
+    	def short value1   = value & 0xFF
+        def short value2 = (value >> 8) & 0xFF
+        [value2, value1]
+    break
+    case 3:
+    	def short value1   = value & 0xFF
+        def short value2 = (value >> 8) & 0xFF
+        def short value3 = (value >> 16) & 0xFF
+        [value3, value2, value1]
+    break
+	case 4:
+    	def short value1 = value & 0xFF
+        def short value2 = (value >> 8) & 0xFF
+        def short value3 = (value >> 16) & 0xFF
+        def short value4 = (value >> 24) & 0xFF
+		[value4, value3, value2, value1]
+	break
+	}
+    } catch (e) {
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Error: integer2Cmd $e Value: $value"
+    }
+}
+
+private getCommandClassVersions() {
+	[0x20: 1, 0x25: 1, 0x70: 1, 0x98: 1, 0x32: 3]
+}
+
+def zwaveEvent(hubitat.zwave.commands.securityv1.SecurityMessageEncapsulation cmd) {
+    def encapsulatedCommand = cmd.encapsulatedCommand(commandClassVersions)
+    if (encapsulatedCommand) {
+        state.sec = 1
+        zwaveEvent(encapsulatedCommand)
+    }
+}
+
+def parse(description) {
+    def result = null
+    if (description.startsWith("Err 106")) {
+        state.sec = 0
+        result = createEvent(descriptionText: description, isStateChange: true)
+    } else if (description != "updated") {
+        def cmd = zwave.parse(description, commandClassVersions)
+        if (cmd) {
+            result = zwaveEvent(cmd)
+            //if (debugEnable) log.debug("'$cmd' parsed to $result")
+        } else {
+            if (debugEnable) log.debug("Couldn't zwave.parse '$description'")
+        }
+    }
+    def now
+    if(location.timeZone)
+    now = new Date().format("yyyy MMM dd EEE h:mm:ss a", location.timeZone)
+    else
+    now = new Date().format("yyyy MMM dd EEE h:mm:ss a")
+    sendEvent(name: "lastActivity", value: now, displayed:false)
+    result
+}
+
+def zwaveEvent(hubitat.zwave.commands.basicv1.BasicReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Basic report received with value of ${cmd.value ? "on" : "off"}"
+	createEvent(name: "switch", value: cmd.value ? "on" : "off", type: "physical")
+}
+
+def zwaveEvent(hubitat.zwave.commands.basicv1.BasicSet cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Basic set received with value of ${cmd.value ? "on" : "off"}"
+	createEvent(name: "switch", value: cmd.value ? "on" : "off", type: "physical")
+}
+
+def zwaveEvent(hubitat.zwave.commands.switchbinaryv1.SwitchBinaryReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Switch Binary report received with value of ${cmd.value ? "on" : "off"}"
+	createEvent(name: "switch", value: cmd.value ? "on" : "off", type: "digital")
+}
+
+def zwaveEvent(hubitat.zwave.commands.centralscenev1.CentralSceneNotification cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    switch (cmd.keyAttributes) {
+       case 0:
+       if (cmd.sceneNumber == 3) createEvent(buttonEvent(7, "pushed", "physical"))
+       else createEvent(buttonEvent(cmd.keyAttributes + 1, (cmd.sceneNumber == 2? "pushed" : "held"), "physical"))
+       break
+       case 1:
+       createEvent(buttonEvent(6, (cmd.sceneNumber == 2? "pushed" : "held"), "physical"))
+       break
+       case 2:
+       null
+       break
+       default:
+       createEvent(buttonEvent(cmd.keyAttributes - 1, (cmd.sceneNumber == 2? "pushed" : "held"), "physical"))
+       break
+    }
+}
+
+def buttonEvent(button, value, type = "digital") {
+    if(button != 6)
+        sendEvent(name:"lastEvent", value: "${value != 'pushed'?' Tap '.padRight(button+5, '▼'):' Tap '.padRight(button+5, '▲')}", displayed:false)
+    else
+        sendEvent(name:"lastEvent", value: "${value != 'pushed'?' Hold ▼':' Hold ▲'}", displayed:false)
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Button ${button} was ${value}"
+    [name: value, value: button, isStateChange:true]
+}
+
+def zwaveEvent(hubitat.zwave.Command cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: Unhandled: $cmd"
+    null
+}
+
+def reset() {
+	def cmds = []
+    cmds << zwave.meterV2.meterReset()
+    cmds << zwave.meterV2.meterGet(scale: 0)
+    cmds << zwave.meterV2.meterGet(scale: 2)
+	commands(cmds, 1000)
+}
+
+def on() {
+    commands([
+        zwave.basicV1.basicSet(value: 0xFF)//,
+        //zwave.basicV1.basicGet()
+    ])
+}
+
+def off() {
+    commands([
+        zwave.basicV1.basicSet(value: 0x00)//,
+        //zwave.basicV1.basicGet()
+    ])
+}
+
+def ping() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: ping()"
+    //refresh()
+}
+
+def poll() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: poll()"
+    //refresh()
+}
+
+def refresh() {
+    if (infoEnable) log.info "${device.label?device.label:device.name}: refresh()"
+    def cmds = []
+    cmds << zwave.basicV1.basicGet()
+    cmds << zwave.meterV3.meterGet(scale: 0)
+	cmds << zwave.meterV3.meterGet(scale: 2)
+    cmds << zwave.protectionV2.protectionGet()
+    return commands(cmds)
+}
+
+private command(hubitat.zwave.Command cmd) {
+    if (state.sec) {
+        zwave.securityV1.securityMessageEncapsulation().encapsulate(cmd).format()
+    } else {
+        cmd.format()
+    }
+}
+
+private commands(commands, delay=500) {
+    delayBetween(commands.collect{ command(it) }, delay)
+}
+
+def pressUpX1() {
+    sendEvent(buttonEvent(1, "pushed"))
+}
+
+def pressDownX1() {
+    sendEvent(buttonEvent(1, "held"))
+}
+
+def pressUpX2() {
+    sendEvent(buttonEvent(2, "pushed"))
+}
+
+def pressDownX2() {
+    sendEvent(buttonEvent(2, "held"))
+}
+
+def pressUpX3() {
+    sendEvent(buttonEvent(3, "pushed"))
+}
+
+def pressDownX3() {
+    sendEvent(buttonEvent(3, "held"))
+}
+
+def pressUpX4() {
+    sendEvent(buttonEvent(4, "pushed"))
+}
+
+def pressDownX4() {
+    sendEvent(buttonEvent(4, "held"))
+}
+
+def pressUpX5() {
+    sendEvent(buttonEvent(5, "pushed"))
+}
+
+def pressDownX5() {
+    sendEvent(buttonEvent(5, "held"))
+}
+
+def holdUp() {
+    sendEvent(buttonEvent(6, "pushed"))
+}
+
+def holdDown() {
+    sendEvent(buttonEvent(6, "held"))
+}
+
+def pressConfig() {
+    sendEvent(buttonEvent(7, "pushed"))
+}
+
+def setDefaultAssociations() {
+    def smartThingsHubID = String.format('%02x', zwaveHubNodeId).toUpperCase()
+    state.defaultG1 = [smartThingsHubID]
+    state.defaultG2 = []
+    state.defaultG3 = []
+}
+
+def setAssociationGroup(group, node, action, endpoint = null){
+    if (! node =~ /[0-9A-F]+/)
+        return
+
+    if (group < 1 || group > maxAssociationGroup())
+        return
+    
+    def associations = state."desiredAssociation${group}"?:[]
+    switch (action) {
+        case "Remove":
+        associations = associations - node
+        break
+        case "Add":
+        associations << node
+        break
+    }
+    state."desiredAssociation${group}" = associations.unique()
+    return
+}
+
+def maxAssociationGroup(){
+   if (!state.associationGroups) {
+       if (logEnable) log.debug "Getting supported association groups from device"
+       zwave.associationV2.associationGroupingsGet() // execute the update immediately
+   }
+   (state.associationGroups?: 5) as int
+}
+
+def processAssociations(){
+   def cmds = []
+   setDefaultAssociations()
+   def associationGroups = maxAssociationGroup()
+   for (int i = 1; i <= associationGroups; i++){
+      if(state."actualAssociation${i}" != null){
+         if(state."desiredAssociation${i}" != null || state."defaultG${i}") {
+            def refreshGroup = false
+            ((state."desiredAssociation${i}"? state."desiredAssociation${i}" : [] + state."defaultG${i}") - state."actualAssociation${i}").each {
+                if (logEnable) log.debug "Adding node $it to group $i"
+                cmds << zwave.associationV2.associationSet(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
+                refreshGroup = true
+            }
+            ((state."actualAssociation${i}" - state."defaultG${i}") - state."desiredAssociation${i}").each {
+                if (logEnable) log.debug "Removing node $it from group $i"
+                cmds << zwave.associationV2.associationRemove(groupingIdentifier:i, nodeId:hubitat.helper.HexUtils.hexStringToInt(it))
+                refreshGroup = true
+            }
+            if (refreshGroup == true) cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
+            else if (logEnable) log.debug "There are no association actions to complete for group $i"
+         }
+      } else {
+         if (logEnable) log.debug "Association info not known for group $i. Requesting info from device."
+         cmds << zwave.associationV2.associationGet(groupingIdentifier:i)
+      }
+   }
+   return cmds
+}
+
+def zwaveEvent(hubitat.zwave.commands.associationv2.AssociationReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    def temp = []
+    if (cmd.nodeId != []) {
+       cmd.nodeId.each {
+          temp += it.toString().format( '%02x', it.toInteger() ).toUpperCase()
+       }
+    } 
+    state."actualAssociation${cmd.groupingIdentifier}" = temp
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Associations for Group ${cmd.groupingIdentifier}: ${temp}"
+    updateDataValue("associationGroup${cmd.groupingIdentifier}", "$temp")
+}
+
+def zwaveEvent(hubitat.zwave.commands.associationv2.AssociationGroupingsReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    sendEvent(name: "groups", value: cmd.supportedGroupings)
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Supported association groups: ${cmd.supportedGroupings}"
+    state.associationGroups = cmd.supportedGroupings
+}
+
+def zwaveEvent(hubitat.zwave.commands.versionv1.VersionReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${cmd}"
+    if(cmd.applicationVersion != null && cmd.applicationSubVersion != null) {
+	    def firmware = "${cmd.applicationVersion}.${cmd.applicationSubVersion.toString().padLeft(2,'0')}"
+        if (infoEnable) log.info "${device.label?device.label:device.name}: Firmware report received: ${firmware}"
+        state.needfwUpdate = "false"
+        createEvent(name: "firmware", value: "${firmware}")
+    }
+}
+
+def zwaveEvent(hubitat.zwave.commands.protectionv2.ProtectionReport cmd) {
+    if (debugEnable) log.debug "${device.label?device.label:device.name}: ${device.label?device.label:device.name}: ${cmd}"
+    if (infoEnable) log.info "${device.label?device.label:device.name}: Protection report received: Local protection is ${cmd.localProtectionState > 0 ? "on" : "off"} & Remote protection is ${cmd.rfProtectionState > 0 ? "on" : "off"}"
+    state.localProtectionState = cmd.localProtectionState
+    state.rfProtectionState = cmd.rfProtectionState
+    //device.updateSetting("disableLocal",[value:cmd.localProtectionState?cmd.localProtectionState:0,type:"enum"])
+    //device.updateSetting("disableRemote",[value:cmd.rfProtectionState?cmd.rfProtectionState:0,type:"enum"])
+    def children = childDevices
+    def childDevice = children.find{it.deviceNetworkId.endsWith("ep101")}
+    if (childDevice) {
+        childDevice.sendEvent(name: "switch", value: cmd.localProtectionState > 0 ? "on" : "off")        
+    }
+    childDevice = children.find{it.deviceNetworkId.endsWith("ep102")}
+    if (childDevice) {
+        childDevice.sendEvent(name: "switch", value: cmd.rfProtectionState > 0 ? "on" : "off")        
+    }
+}

--- a/Drivers/inovelli-switch-red-series-lzw30-sn.src/inovelli-switch-red-series-lzw30-sn.groovy
+++ b/Drivers/inovelli-switch-red-series-lzw30-sn.src/inovelli-switch-red-series-lzw30-sn.groovy
@@ -783,21 +783,35 @@ def setDefaultAssociations() {
     state.defaultG3 = []
 }
 
-def setAssociationGroup(group, node, action, endpoint = null){
-    if (! node =~ /[0-9A-F]+/)
-        return
+def setAssociationGroup(group, nodes, action, endpoint = null){
+    // Normalize the arguments to be backwards compatible with the old method
+    action = "${action}" == "1" ? "Add" : "${action}" == "0" ? "Remove" : "${action}" // convert 1/0 to Add/Remove
+    group  = "${group}" =~ /\d+/ ? (group as int) : group                             // convert group to int (if possible)
+    nodes  = [] + nodes ?: [nodes]                                                    // convert to collection if not already a collection
 
-    if (group < 1 || group > maxAssociationGroup())
+    if (! nodes.every { it =~ /[0-9A-F]+/ }) {
+        log.error "invalid Nodes ${nodes}"
         return
+    }
+
+    if (group < 1 || group > maxAssociationGroup()) {
+        log.error "Association group is invalid 1 <= ${group} <= ${maxAssociationGroup()}"
+        return
+    }
     
     def associations = state."desiredAssociation${group}"?:[]
-    switch (action) {
-        case "Remove":
-        associations = associations - node
-        break
-        case "Add":
-        associations << node
-        break
+    nodes.each { 
+        node = "${it}"
+        switch (action) {
+            case "Remove":
+            if (logEnable) log.debug "Removing node ${node} from association group ${group}"
+            associations = associations - node
+            break
+            case "Add":
+            if (logEnable) log.debug "Adding node ${node} to association group ${group}"
+            associations << node
+            break
+        }
     }
     state."desiredAssociation${group}" = associations.unique()
     return


### PR DESCRIPTION
I updated all the setAssociationGroup commands to work with Hubitat, and to perform some basic level validation, and self-documentation in the user interface.  Also I updated the nzw31s with the nzw31 updated fingerprint so that the upgraded nzw31 dimmers will associate with dimmers if the nzw31s driver so long as the nzw31 driver is not installed.
<img width="195" alt="image" src="https://user-images.githubusercontent.com/15111403/69318435-08738100-0bf2-11ea-91f4-e2663ca5801d.png">

Additionally, I implemented the hubitat HexUtils method to convert the hex node ID to an int, instead of Integer.parseInt(string, radix) method.