### PR TITLE
Allows the use of fan speed control for hubitat users

### DIFF
--- a/Drivers/inovelli-fan-child-device.src/inovelli-fan-child-device.groovy
+++ b/Drivers/inovelli-fan-child-device.src/inovelli-fan-child-device.groovy
@@ -1,0 +1,86 @@
+/**
+ *  Copyright 2018 Eric Maycock
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ */
+metadata {
+	definition (name: "Inovelli Fan Child Device", namespace: "InovelliUSA", author: "Eric Maycock") {
+	capability "Switch Level"
+	capability "Actuator"
+	capability "Switch"
+	capability "Refresh"
+        capability "FanControl"
+
+        command "low"
+        command "medium"
+        command "high"
+	}
+}
+
+void on() {
+	parent.childOn(device.deviceNetworkId)
+}
+
+void off() {
+	parent.childOff(device.deviceNetworkId)
+}
+
+void refresh() {
+	parent.childRefresh(device.deviceNetworkId)
+}
+
+def setLevel(value) {
+	parent.childSetLevel(device.deviceNetworkId, value)
+}
+
+def low() {
+	parent.childSetLevel(device.deviceNetworkId, 33)
+    sendEvent(name: "speed", value: "low")
+}
+def medium() {
+	parent.childSetLevel(device.deviceNetworkId, 66)
+    sendEvent(name: "speed", value: "medium")
+}
+def high() {
+	parent.childSetLevel(device.deviceNetworkId, 99)
+    sendEvent(name: "speed", value: "high")
+}
+
+def setSpeed(fanspeed) {
+    log.info "fan speed set to ${fanspeed}"
+    
+    if (fanspeed == low) {
+        low()
+    log.info "fan speed set to 33"
+    }
+    else if (fanspeed == medium-low) {
+        medium()
+    log.info "fan speed set to 66"
+    }
+    else if (fanspeed == medium) {
+        medium()
+    log.info "fan speed set to 66"
+    }
+    else if (fanspeed == medium-high) {
+        medium()
+    log.info "fan speed set to 66"
+    }
+    else if (fanspeed == high) {
+        high()
+    log.info "fan speed set to 99"
+    }
+    else if (fanspeed == on) {
+        on()
+    }
+    else if (fanspeed == off) {
+        off()
+    }
+}

--- a/Drivers/inovelli-fan-child-device.src/inovelli-fan-child-device.groovy
+++ b/Drivers/inovelli-fan-child-device.src/inovelli-fan-child-device.groovy
@@ -10,7 +10,10 @@
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
  *
+ *  Changes:
+ *  2020-03-03 Allows the use of fan speed control for hubitat users - sgrayban
  */
+
 metadata {
 	definition (name: "Inovelli Fan Child Device", namespace: "InovelliUSA", author: "Eric Maycock") {
 	capability "Switch Level"

--- a/Drivers/inovelli-fan-light-lzw36.src/inovelli-fan-light-lzw36.groovy
+++ b/Drivers/inovelli-fan-light-lzw36.src/inovelli-fan-light-lzw36.groovy
@@ -14,6 +14,8 @@
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
  *
+ *  Changes:
+ *  2020-03-03 Allows the use of fan speed control for hubitat users - sgrayban
  * 
  */
  

--- a/Drivers/inovelli-fan-light-lzw36.src/inovelli-fan-light-lzw36.groovy
+++ b/Drivers/inovelli-fan-light-lzw36.src/inovelli-fan-light-lzw36.groovy
@@ -871,10 +871,10 @@ private channelNumber(String dni) {
 private void createChildDevices() {
     state.oldLabel = device.label
     //for (i in 1..2) {
-        addChildDevice("Switch Level Child Device", "${device.deviceNetworkId}-ep1", [completedSetup: true, label: "${device.displayName} (Light)",
+        addChildDevice("Inovelli Fan Child Device", "${device.deviceNetworkId}-ep1", [completedSetup: true, label: "${device.displayName} (Light)",
             isComponent: false, componentName: "ep1", componentLabel: "Channel 1"
         ])
-        addChildDevice("Switch Level Child Device", "${device.deviceNetworkId}-ep2", [completedSetup: true, label: "${device.displayName} (Fan)",
+        addChildDevice("Inovelli Fan Child Device", "${device.deviceNetworkId}-ep2", [completedSetup: true, label: "${device.displayName} (Fan)",
             isComponent: false, componentName: "ep2", componentLabel: "Channel 2"
         ])
     //}


### PR DESCRIPTION
Changes are as follows:

Created fan child device to allow control via "capability FanControl"
Edited inovelli-fan-light-lzw36.groovy to use the above child device when creating the fan light and fan devices.