### PR TITLE
lzw31-sn: separate name and description in preferences

### DIFF
--- a/Drivers/inovelli-dimmer-red-series-lzw31-sn.src/inovelli-dimmer-red-series-lzw31-sn.groovy
+++ b/Drivers/inovelli-dimmer-red-series-lzw31-sn.src/inovelli-dimmer-red-series-lzw31-sn.groovy
@@ -167,14 +167,16 @@ def generate_preferences()
         {   
             case "number":
                 input "parameter${i}", "number",
-                    title:getParameterInfo(i, "name") + "\n" + getParameterInfo(i, "description") + "\nRange: " + getParameterInfo(i, "options") + "\nDefault: " + getParameterInfo(i, "default"),
+                    title:getParameterInfo(i, "name") ,
+                    description: getParameterInfo(i, "description") + "<br/>Range: " + getParameterInfo(i, "options") + "<br/>Default: " + getParameterInfo(i, "default"),
                     range: getParameterInfo(i, "options")
                     //defaultValue: getParameterInfo(i, "default")
                     //displayDuringSetup: "${it.@displayDuringSetup}"
             break
             case "enum":
                 input "parameter${i}", "enum",
-                    title:getParameterInfo(i, "name"), // + getParameterInfo(i, "description"),
+                    title:getParameterInfo(i, "name"),
+                    description: getParameterInfo(i, "description") + "<br/>Range: " + getParameterInfo(i, "options") + "<br/>Default: " + getParameterInfo(i, "default"),
                     //defaultValue: getParameterInfo(i, "default"),
                     //displayDuringSetup: "${it.@displayDuringSetup}",
                     options: getParameterInfo(i, "options")


### PR DESCRIPTION
 - Preferences are more readable now that names and descriptions are
 separate
 - Use the <br/> markup as line breaks since \n doesn't get translated
 by Hubitat

Before:
![image](https://user-images.githubusercontent.com/81034/100280318-dbe8f800-2f1c-11eb-993b-05fa689febce.png)

After:
![image](https://user-images.githubusercontent.com/81034/100280174-9af0e380-2f1c-11eb-8c11-1f3a464a85bf.png)
