### PR TITLE
Add importUrl to LZW45 Lightstrip Driver definition

### DIFF
--- a/Drivers/inovelli-light-strip-lzw45.src/inovelli-light-strip-lzw45.groovy
+++ b/Drivers/inovelli-light-strip-lzw45.src/inovelli-light-strip-lzw45.groovy
@@ -31,7 +31,7 @@
 import groovy.transform.Field
 
 metadata {
-	definition (name: "Inovelli Light Strip LZW45", namespace: "InovelliUSA", author: "InovelliUSA", importUrl: "") {
+	definition (name: "Inovelli Light Strip LZW45", namespace: "InovelliUSA", author: "InovelliUSA", importUrl: "https://raw.githubusercontent.com/InovelliUSA/Hubitat/master/Drivers/inovelli-light-strip-lzw45.src/inovelli-light-strip-lzw45.groovy") {
 		capability "SwitchLevel"
 		capability "ColorTemperature"
 		capability "ColorControl"


### PR DESCRIPTION
This sets the import URL to the driver file on github so that it's easy to update the driver in the future.