### PR TITLE
Update inovelli-dimmer-lzw31.groovy

### DIFF
--- a/Drivers/inovelli-dimmer-lzw31.src/inovelli-dimmer-lzw31.groovy
+++ b/Drivers/inovelli-dimmer-lzw31.src/inovelli-dimmer-lzw31.groovy
@@ -946,7 +946,7 @@ def setLevel(value) {
 def setLevel(value, duration) {
     if (infoEnable) log.info "${device.label?device.label:device.name}: setLevel($value, $duration)"
     state.lastRan = now()
-    def dimmingDuration = duration < 128 ? duration : 128 + Math.round(duration / 60)
+    def dimmingDuration = duration!=null ? (duration < 128 ? duration : 128 + Math.round(duration / 60) ) : 0
     commands([
         zwave.switchMultilevelV2.switchMultilevelSet(value: value < 100 ? value : 99, dimmingDuration: dimmingDuration)
     ])


### PR DESCRIPTION
Duration parameter is optional and can be null. all this to avoid NP exception.   HE drivers behave this way that NULL is treated as 0