### PR TITLE
Fix issue with switch property not turning on

### DIFF
--- a/Drivers/inovelli-light-strip-lzw45.src/inovelli-light-strip-lzw45.groovy
+++ b/Drivers/inovelli-light-strip-lzw45.src/inovelli-light-strip-lzw45.groovy
@@ -914,7 +914,9 @@ def setColor(value) {
     }
     if ((!colorStaging)){
         if (infoEnable) log.info "${device.label?device.label:device.name}: Bulb is off. Turning on"
-        cmds << zwave.basicV1.basicSet(value: value.level < 100 ? value.level : 99)
+        cmds << zwave.switchMultilevelV2.switchMultilevelSet(value: value.level < 100 ? value.level : 99)
+        cmds << zwave.switchMultilevelV2.switchMultilevelGet()
+        
     }
     sendEvent(name: "colorMode", value: "RGB", descriptionText: "${device.getDisplayName()} color mode is RGB")
     sendEvent(name: "hue", value: value.hue)


### PR DESCRIPTION
With LZW45 off, using the setColor() method turns the actual device on but leaves the device's switch property set to off.  This issue is not present when using the setLevel() method.  This fix simply copies the set level functionality from the setLevel() method to the setColor() method which fixes the problem.