### PR TITLE
Update inovelli-bulb-multi-color-lzw42.groovy

### DIFF
--- a/Drivers/inovelli-bulb-multi-color-lzw42.src/inovelli-bulb-multi-color-lzw42.groovy
+++ b/Drivers/inovelli-bulb-multi-color-lzw42.src/inovelli-bulb-multi-color-lzw42.groovy
@@ -343,7 +343,7 @@ void setColor(value) {
 	}
 	sendToDevice(cmds)
 	eventProcess(name: "colorMode", value: "RGB", descriptionText: "${device.getDisplayName()} color mode is RGB")
-	runIn(dimmingDuration, "refreshColor")
+	runIn(dimmingDuration, "refresh")
 }
 
 void setColorTemperature(temp, level = null, tt = null) {
@@ -364,7 +364,7 @@ void setColorTemperature(temp, level = null, tt = null) {
     if (level) setLevel(level, tt)
 	sendToDevice(cmds)
 	eventProcess(name: "colorMode", value: "CT", descriptionText: "${device.getDisplayName()} color mode is CT")
-	runIn(dimmingDuration, "refreshColor")
+	runIn(dimmingDuration, "refresh")
 }
 
 private void setGenericTempName(temp){


### PR DESCRIPTION
Call `refresh()` instead of `refreshColor`.

Resolves an issue where switching from RGB to CT mode, while simultaneously changing level fails to update current level of bulb in Hubitat states.

For example, if the bulb is set to 2700K and 100%, then you change to [hue:34,saturation:100,level:10], it only updates the hue and saturation in the UI, failing to update the level value. This is most prominent of an issue when switching bulbs from one scene to another using the Room Lighting app.

I can manually call `refresh()` and it will update the displayed level in the UI. Alternatively, the change in this PR calls `refresh()` whenever setting the color or color temperature, ensuring the displayed values from the bulb are the actual current values.