### PR TITLE
remove "auto-bind" code for zigbee groups

### DIFF
--- a/Drivers/inovelli-dimmer-blue-series-vzm31-sn.src/inovelli-dimmer-blue-series-vzm31-sn.groovy
+++ b/Drivers/inovelli-dimmer-blue-series-vzm31-sn.src/inovelli-dimmer-blue-series-vzm31-sn.groovy
@@ -1,4 +1,4 @@
-def getDriverDate() { return "2023-10-14" /*+ orangeRed(" (beta)")*/ }	// **** DATE OF THE DEVICE DRIVER
+def getDriverDate() { return "2023-12-22" /* + orangeRed(" (beta)") */ }	// **** DATE OF THE DEVICE DRIVER
 //  ^^^^^^^^^^  UPDATE THIS DATE IF YOU MAKE ANY CHANGES  ^^^^^^^^^^
 /**
 * Inovelli VZM31-SN Blue Series Zigbee 2-in-1 Dimmer
@@ -174,6 +174,8 @@ def getDriverDate() { return "2023-10-14" /*+ orangeRed(" (beta)")*/ }	// **** D
 * 2023-10-01(MA) remove "beta" designation
 * 2023-10-10(EM) add additional description information for aux switch and non-neutral settings
 * 2023-10-14(MA) fix "Switch Mode" not changing; warn null ClusterID; fix null setLevel
+* 2023-10-18(MA) move configParams map down to the bottom for easier scrolling
+* 2023-12-22(MA) remove (comment out) code that does automatic group binding
 *
 * !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 * !!                                                                 !!
@@ -421,9 +423,9 @@ metadata {
         input name: "groupBinding2", type: "number", title: bold("Group Bind #2"), description: italic("Enter the Zigbee Group ID or leave blank to UNBind"), defaultValue: null, range: "1..65527"
         input name: "groupBinding3", type: "number", title: bold("Group Bind #3"), description: italic("Enter the Zigbee Group ID or leave blank to UNBind"), defaultValue: null, range: "1..65527"
 
-        input name: "infoEnable",          type: "bool",   title: bold("Enable Info Logging"),   defaultValue: true
-        input name: "traceEnable",         type: "bool",   title: bold("Enable Trace Logging"),  defaultValue: false
-        input name: "debugEnable",         type: "bool",   title: bold("Enable Debug Logging"),  defaultValue: false
+        input name: "infoEnable",          type: "bool",   title: bold("Enable Info Logging"),   defaultValue: true,  description: italic("Log general device activity<br>(optional and not required for normal operation)")
+        input name: "traceEnable",         type: "bool",   title: bold("Enable Trace Logging"),  defaultValue: false, description: italic("Additional info for trouble-shooting (not needed unless having issues)")
+        input name: "debugEnable",         type: "bool",   title: bold("Enable Debug Logging"),  defaultValue: false, description: italic("Detailed diagnostic data<br>"+fireBrick("(only enable when asked by a developer)"))
         input name: "disableInfoLogging",  type: "number", title: bold("Disable Info Logging after this number of minutes"),  description: italic("(0=Do not disable)"), defaultValue: 20
         input name: "disableTraceLogging", type: "number", title: bold("Disable Trace Logging after this number of minutes"), description: italic("(0=Do not disable)"), defaultValue: 10
         input name: "disableDebugLogging", type: "number", title: bold("Disable Debug Logging after this number of minutes"), description: italic("(0=Do not disable)"), defaultValue: 5
@@ -438,10 +440,1874 @@ def getReadOnlyParams() {
 	return [0,21,32,33,51,157,257]
 }
 
+
+def infoLogsOff() {
+    log.warn "${device.displayName} " + fireBrick("Disabling Info logging after timeout")
+    device.updateSetting("infoEnable",[value:"false",type:"bool"])
+    //device.updateSetting("disableInfoLogging",[value:"",type:"number"])
+}
+
+def traceLogsOff() {
+    log.warn "${device.displayName} " + fireBrick("Disabling Trace logging after timeout")
+    device.updateSetting("traceEnable",[value:"false",type:"bool"])
+    //device.updateSetting("disableTraceLogging",[value:"",type:"number"])
+}
+
+def debugLogsOff() {
+    log.warn "${device.displayName} " + fireBrick("Disabling Debug logging after timeout")
+    device.updateSetting("debugEnable",[value:"false",type:"bool"])
+    //device.updateSetting("disableDebugLogging",[value:"",type:"number"])
+}
+
+def bind(cmds=[]) {
+    if (infoEnable) log.info "${device.displayName} bind(${cmds})"
+    state.lastCommandSent =						   "bind(${cmds})"
+    state.lastCommandTime = nowFormatted()
+    return cmds
+}
+
+def bindGroup(action="", group=0) {
+    if (infoEnable) log.info "${device.displayName} bindGroup($action, $group))"
+    state.lastCommandSent =                        "bindGroup($action, $group))"
+    state.lastCommandTime = nowFormatted()
+	def cmds = []
+	if (action=="bind" || action=="unbind") {
+		cmds += ["zdo $action 0x${device.deviceNetworkId} 0x02 0x01 0x0006 {${device.zigbeeId}} {${zigbee.convertToHexString(group.toInteger(),4)}}"]
+		cmds += ["zdo $action 0x${device.deviceNetworkId} 0x02 0x01 0x0008 {${device.zigbeeId}} {${zigbee.convertToHexString(group.toInteger(),4)}}"]
+		cmds += "delay 60000"		//binding can take up to 60 seconds 
+		cmds += getParameter(51)	//update number of bindings counter
+		sendHubCommand(new hubitat.device.HubMultiAction(cmds, hubitat.device.Protocol.ZIGBEE))
+	} else {
+		if (infoEnable) log.warn "${device.displayName} " + fireBrick("Invalid Bind action: '$action'")
+		}
+    if (debugEnable) log.debug "${device.displayName} bindGroup $cmds"
+    return
+}
+
+def bindInitiator() {
+    if (infoEnable) log.info "${device.displayName} bindInitiator()" 
+    state.lastCommandSent =            			   "bindInitiator()" 
+    state.lastCommandTime = nowFormatted()
+    def cmds = zigbee.command(0xfc31,0x04,["mfgCode":"0x122F"],shortDelay,"0")
+    if (debugEnable) log.debug "${device.displayName} bindInitiator $cmds"
+    return cmds
+}
+
+def bindTarget(Integer timeout=30) {
+    if (infoEnable) log.info "${device.displayName} bindTarget($timeout)"
+    state.lastCommandSent =             		   "bindTarget($timeout)"
+    state.lastCommandTime = nowFormatted()
+    def cmds = setZigbeeAttribute(3,0,timeout,16)
+    if (debugEnable) log.debug "${device.displayName} bindTarget $cmds"
+    return cmds
+}
+
+def calculateParameter(paramNum) {
+	paramNum = paramNum?:0
+    def value = Math.round((settings?."parameter${paramNum}"!=null?settings?."parameter${paramNum}":getDefaultValue(paramNum))?.toFloat())?.toInteger()
+    switch (paramNum){
+        case 9:     //Min Level
+        case 10:    //Max Level
+        case 13:    //Default Level (local)
+        case 14:    //Default Level (remote)
+        case 15:    //Level after power restored
+		case 55:	//Double-Tap UP Level
+		case 56:	//Double-Tap DOWN Level
+            value = convertPercentToByte(value)    //convert levels from percent to byte values before sending to the device
+            break
+        case 18:    //Active Power Reports (percent change)
+        case 97:    //LED Bar Intensity(when On)
+        case 98:    //LED Bar Intensity(when Off)
+			value = Math.min(Math.max(value.toInteger(),0),100)
+            break
+        case 95:    //custom hue for LED Bar (when On)
+        case 96:    //custom hue for LED Bar (when Off)
+            //360-hue values need to be converted to byte values before sending to the device
+            if (settings."parameter${paramNum}custom" =~ /^([0-9]{1}|[0-9]{2}|[0-9]{3})$/) {
+                value = Math.round((settings."parameter${paramNum}custom").toInteger()/360*255)
+            } else {   //else custom hue is invalid format or not selected
+                if(settings."parameter${paramNum}custom"!=null) {
+                    device.removeSetting("parameter${paramNum}custom")
+                    if (infoEnable||traceEnable||debugEnable) log.warn "${device.displayName} " + fireBrick("Cleared invalid custom hue: ${settings."parameter${paramNum}custom"}")
+                }
+            }
+            break
+    }
+    return value?:0
+}
+
+def calculateSize(size) {
+    if (traceEnable) log.trace "${device.displayName} calculateSize(${size})"
+	if (size==null || size==" ") size = configParams["parameter${number.toString().padLeft(3,'0')}"]?.size?:8
+    if      (size.toInteger() == 1)  return 0x10    //1-bit boolean
+    else if (size.toInteger() == 8)  return 0x20    //1-byte unsigned integer
+    else if (size.toInteger() == 16) return 0x21    //2-byte unsigned integer
+    else if (size.toInteger() == 24) return 0x22    //3-byte unsigned integer
+    else if (size.toInteger() == 32) return 0x23    //4-byte unsigned integer
+    else if (size.toInteger() == 40) return 0x24    //5-byte unsigned integer
+    else if (size.toInteger() == 48) return 0x25    //6-byte unsigned integer
+    else if (size.toInteger() == 56) return 0x26    //7-byte unsigned integer
+    else if (size.toInteger() == 64) return 0x27    //8-byte unsigned integer
+    else                             return 0x20    //default to 1-byte unsigned if no other matches
+}
+
+def clearSetting(i) {
+	i = i?:0
+	def cleared = false
+	if (settings."parameter${i}"!=null)   {cleared=true; device.removeSetting("parameter" + i)}
+	if (state."parameter${i}value"!=null) {cleared=true; state.remove("parameter" + i + "value")}
+	if (cleared && (traceEnable||debugEnable)) log.trace "${device.displayName} cleared P${i} since it is the default"
+}
+
+def clusterLookup(cluster) {
+	if (cluster==null) return "null ClusterID"
+	else {
+		//return zigbee.clusterLookup(cluster)
+		return zigbee.clusterLookup(cluster)?:cluster==0x8021?"Binding Cluster":
+										   cluster==0x8022?"UNBinding Cluster":
+										   cluster==0x8032?"Routing Table Cluster":
+										   cluster==0xFC31?"Private Cluster":
+										   "Cluster:0x${zigbee.convertToHexString(cluster,4)}"
+	}
+}
+
+def configure(option) {    //THIS GETS CALLED AUTOMATICALLY WHEN NEW DEVICE IS ADDED OR WHEN CONFIGURE BUTTON SELECTED ON DEVICE PAGE
+    option = (option==null||option==" ")?"":option
+    if (infoEnable) log.info "${device.displayName} configure($option)"
+    state.lastCommandSent =                        "configure($option)"
+    state.lastCommandTime = nowFormatted()
+    sendEvent(name: "numberOfButtons", value: 14)
+    def cmds = []
+	if (infoEnable) log.info "${device.displayName} re-establish lifeline bindings to hub"
+//  cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0000 {${device.zigbeeId}} {}", "delay ${666}"] //Basic Cluster
+//  cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0x0000 {${device.zigbeeId}} {}", "delay ${666}"] //Basic Cluster ep2
+//  cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0003 {${device.zigbeeId}} {}", "delay ${666}"] //Identify Cluster
+//  cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0x0003 {${device.zigbeeId}} {}", "delay ${666}"] //Identify Cluster ep2
+//  cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0004 {${device.zigbeeId}} {}", "delay ${666}"] //Group Cluster
+//  cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0x0004 {${device.zigbeeId}} {}", "delay ${666}"] //Group Cluster ep2
+//  cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0005 {${device.zigbeeId}} {}", "delay ${666}"] //Scenes Cluster
+//  cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0x0005 {${device.zigbeeId}} {}", "delay ${666}"] //Scenes Cluster ep2
+	cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0006 {${device.zigbeeId}} {}", "delay ${666}"] //On_Off Cluster
+//  cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0x0006 {${device.zigbeeId}} {}", "delay ${666}"] //On_Off Cluster ep2
+	cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0008 {${device.zigbeeId}} {}", "delay ${666}"] //Level Control Cluster
+//  cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0x0008 {${device.zigbeeId}} {}", "delay ${666}"] //Level Control Cluster ep2
+	cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0019 {${device.zigbeeId}} {}", "delay ${666}"] //OTA Upgrade Cluster
+	if (state.model?.substring(0,5)!="VZM35") {  //Fan does not support power/energy reports
+		cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0702 {${device.zigbeeId}} {}", "delay ${666}"] //Simple Metering - to get energy reports
+		cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0B04 {${device.zigbeeId}} {}", "delay ${666}"] //Electrical Measurement - to get power reports
+	}
+	cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x8021 {${device.zigbeeId}} {}", "delay ${666}"] //Binding Cluster 
+	cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x8022 {${device.zigbeeId}} {}", "delay ${666}"] //UnBinding Cluster
+	cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0xFC31 {${device.zigbeeId}} {}", "delay ${666}"] //Private Cluster
+	cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0xFC31 {${device.zigbeeId}} {}", "delay ${666}"] //Private Cluster ep2
+
+    if (option=="") {		//IF   we didn't pick an option 
+		cmds += refresh()	//THEN refresh read-only and key parameters
+    } else { 				//ELSE read device attributes and pass on to update settings.
+		cmds += readDeviceAttributes()
+		cmds += updated(option)
+	}
+    if (debugEnable) log.debug "${device.displayName} configure $cmds"
+    return cmds
+}
+
+def convertByteToPercent(int value=0) {                  //convert a 0-254 range where 254=100%.  255 is reserved for special meaning.
+    //if (debugEnable) log.debug "${device.displayName} convertByteToPercent(${value})"
+    value = value==null?0:value                          //default to 0 if null
+    value = Math.min(Math.max(value.toInteger(),0),255)  //make sure input byte value is in the 0-255 range
+    value = value>=255?256:value                         //this ensures that byte values of 255 get rounded up to 101%
+    value = Math.ceil(value/255*100)                     //convert to 0-100 where 254=100% and 255 becomes 101 for special meaning
+    return value
+}
+
+def convertPercentToByte(int value=0) {                  //convert a 0-100 range where 100%=254.  255 is reserved for special meaning.
+    //if (debugEnable) log.debug "${device.displayName} convertPercentToByte(${value})"
+    value = value==null?0:value                          //default to 0 if null
+    value = Math.min(Math.max(value.toInteger(),0),101)  //make sure input percent value is in the 0-101 range
+    value = Math.floor(value/100*255)                    //convert to 0-255 where 100%=254 and 101 becomes 255 for special meaning
+    value = value==255?254:value                         //this ensures that 100% rounds down to byte value 254
+    value = value>255?255:value                          //this ensures that 101% rounds down to byte value 255
+    return value
+}
+
+def cycleSpeed() {    // FOR FAN ONLY
+    def cmds =[]
+    if (parameter158=="1" || parameter258=="1") cmds += toggle()    //if we are in on/off mode then do a toggle instead of cycle
+    else {
+        def currentLevel = device.currentValue("level")==null?0:device.currentValue("level").toInteger()
+        if (device.currentValue("switch")=="off") currentLevel = 0
+		boolean smartMode = device.currentValue("smartFan")=="Enabled"
+        def newLevel = 0
+		def newSpeed =""
+		if      (currentLevel<=0 ) {newLevel=20;               newSpeed="low" }
+		else if (currentLevel<=20) {newLevel=smartMode?40:60;  newSpeed=smartMode?"medium-low":"medium"}
+		else if (currentLevel<=40) {newLevel=60;               newSpeed="medium"}
+		else if (currentLevel<=60) {newLevel=smartMode?80:100; newSpeed=smartMode?"medium-high":"high"}
+		else if (currentLevel<=80) {newLevel=100;              newSpeed="high"}
+        else                       {newLevel=0;                newSpeed="off"}
+        if (infoEnable) log.info "${device.displayName} cycleSpeed(${device.currentValue("speed")}->${newSpeed})"
+        state.lastCommandSent =                        "cycleSpeed(${device.currentValue("speed")}->${newSpeed})"
+        state.lastCommandTime = nowFormatted()
+        cmds += zigbee.setLevel(newLevel)
+        if (debugEnable) log.debug "${device.displayName} cycleSpeed $cmds"
+    }
+    return cmds
+}
+
+def getDefaultValue(paramNum=0) {
+	paramValue=configParams["parameter${paramNum.toString()?.padLeft(3,"0")}"]?.default?.toInteger()
+	return paramValue?:0
+	}
+
+def identify(seconds) {
+    if (infoEnable) log.info "${device.displayName} identify(${seconds==null?"":seconds})"
+    state.lastCommandSent =                        "identify(${seconds==null?"":seconds})"
+    state.lastCommandTime = nowFormatted()
+    def cmds = setZigbeeAttribute(3,0,seconds,16)
+    if (debugEnable) log.debug "${device.displayName} identify $cmds"
+    return cmds
+}
+
+def initialize() {    //CALLED DURING HUB BOOTUP IF "INITIALIZE" CAPABILITY IS DECLARED IN METADATA SECTION
+    log.info "${device.displayName} initialize()"
+    //save the group IDs before clearing all the state variables and reset them after
+	if (state.groupBinding1) saveBinding1 = state.groupBinding1
+	if (state.groupBinding2) saveBinding2 = state.groupBinding2
+	if (state.groupBinding3) saveBinding3 = state.groupBinding3
+    state.clear()
+	if (saveBinding1) state.groupBinding1 = saveBinding1
+	if (saveBinding2) state.groupBinding2 = saveBinding2
+	if (saveBinding3) state.groupBinding3 = saveBinding3
+    state.lastCommandSent = "initialize()"
+    state.lastCommandTime = nowFormatted()
+    state.driverDate = getDriverDate()
+	state.model = device.getDataValue('model')
+    device.removeSetting("parameter23level")
+    device.removeSetting("parameter95custom")
+    device.removeSetting("parameter96custom")
+    def cmds = []
+	cmds += ledEffectOne(1234567,255,0,0,0)	//clear any outstanding oneLED Effects
+	cmds += ledEffectAll(255,0,0,0)			//clear any outstanding allLED Effects
+    cmds += refresh()
+    if (debugEnable) log.debug "${device.displayName} initialize $cmds"
+    return cmds
+}
+
+def installed() {    //THIS IS CALLED WHEN A DEVICE IS INSTALLED
+    log.info "${device.displayName} installed()"
+    state.lastCommandSent =        "installed()"
+    state.lastCommandTime = nowFormatted()
+    state.driverDate = getDriverDate()
+	state.model = device.getDataValue('model')
+    log.info "${device.displayName} Driver Date $state.driverDate"
+    log.info "${device.displayName} Model=$state.model"
+    //configure()     //I confirmed configure() gets called at Install time so this isn't needed here
+    return
+}
+
+def intTo8bitUnsignedHex(value) {
+    return zigbee.convertToHexString(value.toInteger(),2)
+}
+
+def intTo16bitUnsignedHex(value) {
+    return zigbee.convertToHexString(value.toInteger(),4)
+}
+
+def intTo32bitUnsignedHex(value) {
+    return hexStr = zigbee.convertToHexString(value.toInteger(),8)
+}
+
+def ledEffectAll(effect=255, color=0, level=100, duration=60) {
+	effect   = effect.toString().split(/=/)[0]
+	def effectName = "unknown($effect)"
+    switch (effect){
+        case "255":	effectName = "Stop"; break
+        case "1":	effectName = "Solid"; break
+        case "2":	effectName = "Fast Blink"; break
+        case "3":	effectName = "Slow Blink"; break
+        case "4":	effectName = "Pulse"; break
+        case "5":	effectName = "Chase"; break
+        case "6":	effectName = "Open/Close"; break
+        case "7":	effectName = "Small-to-Big"; break
+        case "8":	effectName = "Aurora"; break
+        case "9":	effectName = "Slow Falling"; break
+        case "10":	effectName = "Medium Falling"; break
+        case "11":	effectName = "Fast Falling"; break
+        case "12":	effectName = "Slow Rising"; break
+        case "13":	effectName = "Medium Rising"; break
+        case "14":	effectName = "Fast Rising"; break
+        case "15":	effectName = "Medium Blink"; break
+        case "16":	effectName = "Slow Chase"; break
+        case "17":	effectName = "Fast Chase"; break
+        case "18":	effectName = "Fast Siren"; break
+        case "19":	effectName = "Slow Siren"; break
+        case "0":	effectName = "LEDs Off"; break
+		default:	effectName = "Unknown Effect #$effect"; break
+	}
+    sendEvent(name:"ledEffect", value: "$effectName All")
+    if (infoEnable) log.info "${device.displayName} ledEffectAll(${effect},${color},${level},${duration})"
+    state.lastCommandSent =                        "ledEffectAll(${effect},${color},${level},${duration})"
+    state.lastCommandTime = nowFormatted()
+    effect   = Math.min(Math.max((effect!=null?effect:255).toInteger(),0),255)
+    color    = Math.min(Math.max((color!=null?color:0).toInteger(),0),255)
+    level    = Math.min(Math.max((level!=null?level:100).toInteger(),0),100)
+    duration = Math.min(Math.max((duration!=null?duration:60).toInteger(),0),255)
+    def cmds =[]
+    Integer cmdEffect = effect.toInteger()
+    Integer cmdColor = color.toInteger()
+    Integer cmdLevel = level.toInteger()
+    Integer cmdDuration = duration.toInteger()
+    cmds += zigbee.command(0xfc31,0x01,["mfgCode":"0x122F"],shortDelay,"${intTo8bitUnsignedHex(cmdEffect)} ${intTo8bitUnsignedHex(cmdColor)} ${intTo8bitUnsignedHex(cmdLevel)} ${intTo8bitUnsignedHex(cmdDuration)}")
+    if (debugEnable) log.debug "${device.displayName} ledEffectAll $cmds"
+    return cmds
+}
+                                        
+def ledEffectOne(lednum, effect=255, color=0, level=100, duration=60) {
+	lednum   = lednum.toString().split(/ /)[0].replace(",","")
+	effect   = effect.toString().split(/=/)[0]
+	def effectName = "unknown($effect)"
+    switch (effect){
+        case "255":	effectName = "Stop"; break
+        case "1":	effectName = "Solid"; break
+        case "2":	effectName = "Fast Blink"; break
+        case "3":	effectName = "Slow Blink"; break
+        case "4":	effectName = "Pulse"; break
+        case "5":	effectName = "Chase"; break
+        case "6":	effectName = "Falling"; break
+        case "7":	effectName = "Rising"; break
+        case "8":	effectName = "Aurora"; break
+        case "0":	effectName = "LEDs Off"; break
+		default:	effectName = "Unknown Effect #$effect"; break
+	}
+	sendEvent(name:"ledEffect", value: "$effectName LED${lednum.toString().split(/ /)[0]}")
+    if (infoEnable) log.info "${device.displayName} ledEffectOne(${lednum},${effect},${color},${level},${duration})"
+    state.lastCommandSent =                        "ledEffectOne(${lednum},${effect},${color},${level},${duration})"
+    state.lastCommandTime = nowFormatted()
+    effect   = Math.min(Math.max((effect!=null?effect:255).toInteger(),0),255)
+    color    = Math.min(Math.max((color!=null?color:0).toInteger(),0),255)
+    level    = Math.min(Math.max((level!=null?level:100).toInteger(),0),100)
+    duration = Math.min(Math.max((duration!=null?duration:60).toInteger(),0),255)
+    def cmds = []
+    lednum.toString().each {
+        it= Math.min(Math.max((it!=null?it:1).toInteger(),1),7)
+        Integer cmdLedNum = (it.toInteger()-1)    //lednum is 0-based in firmware 
+        Integer cmdEffect = effect.toInteger()
+        Integer cmdColor = color.toInteger()
+        Integer cmdLevel = level.toInteger()
+        Integer cmdDuration = duration.toInteger()
+        cmds += zigbee.command(0xfc31,0x03,["mfgCode":"0x122F"],100,"${intTo8bitUnsignedHex(cmdLedNum)} ${intTo8bitUnsignedHex(cmdEffect)} ${intTo8bitUnsignedHex(cmdColor)} ${intTo8bitUnsignedHex(cmdLevel)} ${intTo8bitUnsignedHex(cmdDuration)}")
+    }
+    if (debugEnable) log.debug "${device.displayName} ledEffectOne $cmds"
+    return cmds
+}
+
+def nowFormatted() {
+    if(location.timeZone) return new Date().format("yyyy-MMM-dd h:mm:ss a", location.timeZone)
+    else                  return new Date().format("yyyy MMM dd EEE h:mm:ss a")
+}
+
+def off() {
+	if (infoEnable) log.info "${device.displayName} off()"
+    state.lastCommandSent =                        "off()"
+    state.lastCommandTime = nowFormatted()
+    def cmds = []
+    cmds += zigbee.off(shortDelay)
+    if (debugEnable) log.debug "${device.displayName} off $cmds"
+    return cmds
+}
+
+def on() {
+    if (infoEnable) log.info "${device.displayName} on()"
+    state.lastCommandSent =                        "on()"
+    state.lastCommandTime = nowFormatted()
+    def cmds = []
+    if (settings.parameter23?.toInteger()>0) cmds += quickStart() //do quickStart if enabled
+	else cmds += zigbee.on(shortDelay)						  //ELSE just turn On
+    if (debugEnable) log.debug "${device.displayName} on $cmds"
+    return cmds
+}
+def traceCluster(String description) {
+    Map descMap = zigbee.parseDescriptionAsMap(description)
+    //try {      def eventDesc=zigbee.getEvent(description)}
+	//catch (e) {def eventDesc=null}
+	def traceClusterName= clusterLookup(descMap.clusterInt?.toInteger())
+	log.trace "${device.displayName} ${darkOrange(traceClusterName)} " +
+		"(cluster:${descMap.clusterId!=null?descMap.clusterId:descMap.cluster}" +
+        (descMap.attrId==null?"":" attr:${descMap.attrId}") +
+        (descMap.value ==null?"":" value:${descMap.value}") +
+        (descMap.data  ==null?"":" data:${descMap.data}") + 
+        ")"	
+}
+
+def parse(String description) {
+    if (traceEnable) log.trace "${device.displayName} parse($description)"
+    Map descMap = zigbee.parseDescriptionAsMap(description)
+    try {
+		if (debugEnable && (zigbee.getEvent(description)!=[:])) log.debug "${device.displayName} zigbee.getEvent ${zigbee.getEvent(description)}"
+	} catch (e) {
+		if (debugEnable) log.debug "${device.displayName} "+magenta(bold("There was an error while calling zigbee.getEvent: $description"))
+	}
+	def attrId=		descMap.attrId
+    def attrInt=	descMap.attrInt
+    def clusterId=	descMap.clusterId!=null?descMap.clusterId:descMap.cluster
+    def clusterInt=	descMap.clusterInt
+	def clusterName=clusterLookup(clusterInt)
+	def valueInt	//declared empty at top level so values can be assigned in each case and then displayed at the bottom
+    //try {
+	//	def valueInt=Integer.parseInt(descMap['value'],16)
+	//} catch (e) {
+	//	def valueInt=null
+	//}
+    def valueStr =   descMap['value']?:"unknown"
+    switch (clusterInt){
+        case 0x0000:    //BASIC CLUSTER
+            if (traceEnable||debugEnable) traceCluster(description)
+            switch (attrInt) {
+                case 0x0000:
+                    if (infoEnable) log.info "${device.displayName} ZCL Version=$valueStr"
+                    state.zclVersion = valueStr
+                    break
+                case 0x0001:
+                    if (infoEnable) log.info "${device.displayName} Application Version=$valueStr"
+                    state.applicationVersion = valueStr
+                    break
+                case 0x0002:
+                    if (infoEnable) log.info "${device.displayName} Stack Version=$valueStr"
+                    state.stackVersion = valueStr
+                    break
+                case 0x0003:
+                    if (infoEnable) log.info "${device.displayName} HW Version=$valueStr"
+                    state.hwVersion = valueStr
+                    break
+                case 0x0004:
+                    if (infoEnable) log.info "${device.displayName} Mfg=$valueStr"
+                    state.manufacturer = valueStr
+					if (device.getDataValue('manufacturer')!= valueStr) device.updateDataValue('manufacturer',valueStr)
+                    break
+                case 0x0005:
+                    if (infoEnable) log.info "${device.displayName} Model=$valueStr"
+                    state.model = valueStr
+					if (device.getDataValue('model')!= valueStr) device.updateDataValue('model',valueStr)
+                    break
+                case 0x0006:
+                    if (infoEnable) log.info "${device.displayName} FW Date=$valueStr"
+					state.fwDate = valueStr
+                    break
+                case 0x0007:
+                    valueInt = Integer.parseInt(descMap['value'],16)
+                    valueStr = (valueInt==0?"Non-Neutral":(valueInt==1?"Neutral":"undefined"))
+                    if (infoEnable) log.info "${device.displayName} Power Source=$valueInt ($valueStr)"
+					sendEvent(name:"powerSource", value:valueStr)
+                    state.parameter21value = valueInt
+                    device.updateSetting("parameter21",[value:"${valueInt}",type:"enum"]) 
+                    break
+                case 0x4000:
+                    if (infoEnable) log.info "${device.displayName} FW Version=$valueStr"
+					state.fwVersion = valueStr
+                    break
+                default:
+                    log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
+                    break
+            }
+            break
+        case 0x0001:    //Power configuration
+            //if (infoEnable||debugEnable) log.info "${device.displayName} " + darkOrange("Power_Configuration Cluster:") + (debugEnable?descMap:"")
+            if (infoEnable||traceEnable||debugEnable) traceCluster(description)
+            break
+        case 0x0002:    //Device temperature configuration
+            //if (infoEnable||debugEnable) log.info "${device.displayName} " + darkOrange("Device_Temperature Cluster:") + (debugEnable?descMap:"")
+            if (infoEnable||traceEnable||debugEnable) traceCluster(description)
+            break
+        case 0x0003:    //IDENTIFY CLUSTER
+            if (traceEnable||debugEnable) traceCluster(description)
+            switch (attrInt) {
+                case 0x0000:
+                    if (infoEnable) log.info "${device.displayName} Remaining Identify Time=${zigbee.convertHexToInt(valueStr)}s"
+                    break
+                default:
+                    log.warn "${device.displayName} "+fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
+                    break
+            }
+            break
+        case 0x0004:    //GROUP CLUSTER
+            if (traceEnable||debugEnable) traceCluster(description)
+            switch (attrInt) {
+                case 0x0000:
+                    if (infoEnable) log.info "${device.displayName} Group Name Support=$valueStr"
+                    break
+                default:
+                    if (attrInt==null && descMap.messageType=="00" && descMap.direction=="01") {
+						def groupNumHex = descMap.data[2]+descMap.data[1]
+						def groupNumInt = zigbee.convertHexToInt(groupNumHex)
+						switch (descMap.command) {
+							case "00":
+								if (infoEnable) log.info "${device.displayName} Add Group $groupNumInt (0x$groupNumHex)"
+								//bindGroup("bind",groupNumInt)
+								//if (settings.groupBinding1==null || settings.groupBinding1?.toInteger()==groupNumInt || state.groupBinding1?.toInteger()==groupNumInt) {
+								//	device.updateSetting("groupBinding1",[value:groupNumInt,type:"number"])
+								//	state.groupBinding1=groupNumInt
+								//} else if (settings.groupBinding2==null || settings.groupBinding2?.toInteger()==groupNumInt || state.groupBinding2?.toInteger()==groupNumInt) {
+								//	device.updateSetting("groupBinding2",[value:groupNumInt,type:"number"])
+								//	state.groupBinding2=groupNumInt
+								//} else if (settings.groupBinding3==null || settings.groupBinding3?.toInteger()==groupNumInt || state.groupBinding3?.toInteger()==groupNumInt) {
+								//	device.updateSetting("groupBinding3",[value:groupNumInt,type:"number"])
+								//	state.groupBinding3=groupNumInt
+								//}
+								break
+							case "01":
+								if (infoEnable) log.info "${device.displayName} View Group $groupNumInt (0x$groupNumHex)"
+								break
+							case "02":
+								if (infoEnable) log.info "${device.displayName} Get Group $groupNumInt (0x$groupNumHex)"
+								break
+							case "03":
+								if (infoEnable) log.info "${device.displayName} Remove Group $groupNumInt (0x$groupNumHex)"
+								//bindGroup("unbind",groupNumInt)
+								//if      (settings.groupBinding1?.toInteger()==groupNumInt || state.groupBinding1?.toInteger()==groupNumInt) {device.removeSetting("groupBinding1"); state.remove(groupBinding1)}
+								//else if (settings.groupBinding2?.toInteger()==groupNumInt || state.groupBinding2?.toInteger()==groupNumInt) {device.removeSetting("groupBinding2"); state.remove(groupBinding2)}
+								//else if (settings.groupBinding3?.toInteger()==groupNumInt || state.groupBinding3?.toInteger()==groupNumInt) {device.removeSetting("groupBinding3"); state.remove(groupBinding3)}
+								break
+							case "04":
+								if (infoEnable) log.info "${device.displayName} Remove All Groups"
+								device.removeSetting("groupBinding1"); state.remove(groupBinding1)
+								device.removeSetting("groupBinding2"); state.remove(groupBinding2)
+								device.removeSetting("groupBinding3"); state.remove(groupBinding3)
+								break
+							case "05":
+								if (infoEnable) log.info "${device.displayName} Add group if Identifying"
+								break
+							default:
+								log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+								break
+						}
+						// remove duplicate groups
+						if (settings.groupBinding3!=null && settings.groupBinding3==settings.groupBinding2) {device.removeSetting("groupBinding3"); state.remove(groupBinding3); log.info "${device.displayName} Removed duplicate Group Bind #3"}
+						if (settings.groupBinding2!=null && settings.groupBinding2==settings.groupBinding1) {device.removeSetting("groupBinding2"); state.remove(groupBinding2); log.info "${device.displayName} Removed duplicate Group Bind #2"}
+						if (settings.groupBinding1!=null && settings.groupBinding1==settings.groupBinding3) {device.removeSetting("groupBinding3"); state.remove(groupBinding3); log.info "${device.displayName} Removed duplicate Group Bind #3"}
+					} else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
+                    break
+            }
+            break
+        case 0x0005:    //SCENES CLUSTER
+            if (traceEnable||debugEnable) traceCluster(description)
+            switch (attrInt) {
+                case 0x0000:
+                    if (infoEnable) log.info "${device.displayName} Scene Count=$valueStr"
+                    break
+                case 0x0001:
+                    if (infoEnable) log.info "${device.displayName} Current Scene=$valueStr"
+                    break
+                case 0x0002:
+                    if (infoEnable) log.info "${device.displayName} Current Group=$valueStr"
+                    break
+                case 0x0003:
+                    if (infoEnable) log.info "${device.displayName} Scene Valid=$valueStr"
+                    break
+                case 0x0004:
+                    if (infoEnable) log.info "${device.displayName} Scene Name Support=$valueStr"
+                    break
+                default:
+                    log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
+                    break
+            }
+            break
+        case 0x0006:    //ON_OFF CLUSTER
+            if (traceEnable||debugEnable) traceCluster(description)
+            switch (attrInt) {
+                case 0x0000:
+                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        valueStr = (valueInt==0?"off":(valueInt==1?"on":"undefined"))
+                        if (infoEnable) log.info "${device.displayName} Switch=$valueInt ($valueStr)"
+                        sendEvent(name:"switch", value: valueStr)
+						def currentLevel = device.currentValue("level")==null?0:device.currentValue("level").toInteger()
+                        if (state.model?.substring(0,5)=="VZM35") { //FOR FAN ONLY 
+							if (device.currentValue("smartFan")=="Enabled") {
+								if      (currentLevel<=20)  newSpeed="low"
+								else if (currentLevel<=40)  newSpeed="medium-low"
+								else if (currentLevel<=60)  newSpeed="medium"
+								else if (currentLevel<=80)  newSpeed="medium-high"
+								else if (currentLevel<=100) newSpeed="high"
+							} else {
+								if      (currentLevel<=33)  newSpeed="low"
+								else if (currentLevel<=66)  newSpeed="medium"
+								else if (currentLevel<=100) newSpeed="high"
+								}
+                            if      (valueStr=="off")                        newSpeed="off"
+                            else if (parameter158=="1" || parameter258=="1") newSpeed="high"
+                            if (traceEnable||debugEnable) log.trace "${device.displayName} Speed=${newSpeed}"
+                            sendEvent(name:"speed", value: "${newSpeed}")   
+                        }
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+                    break
+                case 0x4000:
+                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        if (infoEnable) log.info "${device.displayName} Global Scene Control " + descMap
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap																									  
+                    break
+                case 0x4001:
+                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        if (infoEnable) log.info "${device.displayName} On Time=${valueInt/10}s"
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap																									  
+                    break
+                case 0x4002:
+                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        if (infoEnable) log.info "${device.displayName} Off Wait Time=${valueInt/10}s"
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap																									  
+                    break
+                case 0x4003:
+                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        valueStr = (valueInt==0?"off":(valueInt==1?"on":(valueInt==2?"toggle":(valueInt==255?"Previous":"undefined"))))
+                        if (infoEnable) log.info "${device.displayName} Power-On State=$valueInt ($valueStr)"
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap																									  
+                    break
+                default:
+                    if (descMap.profileId=="0000" && descMap.command=="00" && descMap.direction=="00") {
+                        if (traceEnable||debugEnable) log.info "${device.displayName} " + 
+							fireBrick("MATCH DESCRIPTOR REQUEST Device:${descMap.data[2]}${descMap.data[1]} Profile:${descMap.data[4]}${descMap.data[3]} Cluster:${descMap.data[7]}${descMap.data[6]}")
+                    } else if (attrInt==null && descMap.command=="0B" && descMap.direction=="01") {
+                        if (settings?.parameter51) {    //not sure why the firmware sends these when there are no bindings
+                            if (descMap.data[0]=="00" && infoEnable) log.info "${device.displayName} Bind Command Sent: Switch OFF"
+                            if (descMap.data[0]=="01" && infoEnable) log.info "${device.displayName} Bind Command Sent: Switch ON"
+                            if (descMap.data[0]=="02" && infoEnable) log.info "${device.displayName} Bind Command Sent: Toggle"
+                        }
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
+                    break
+            }
+            break
+        case 0x0008:    //LEVEL CONTROL CLUSTER
+            if (traceEnable||debugEnable) traceCluster(description)
+            switch (attrInt) {
+                case 0x0000:
+                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        valueInt=Math.min(Math.max(valueInt.toInteger(),0),254)
+                        def percentValue = convertByteToPercent(valueInt)
+                        valueStr = percentValue.toString()+"%"
+                        if (infoEnable) log.info "${device.displayName} Level=$valueInt ($valueStr)"
+                        sendEvent(name:"level", value: percentValue, unit: "%")
+		                def newSpeed =""
+                        if (state.model?.substring(0,5)=="VZM35") { //FOR FAN ONLY
+							if (device.currentValue("smartFan")=="Enabled") {
+								if      (percentValue<=20)  newSpeed="low"
+								else if (percentValue<=40)  newSpeed="medium-low"
+								else if (percentValue<=60)  newSpeed="medium"
+								else if (percentValue<=80)  newSpeed="medium-high"
+								else if (percentValue<=100) newSpeed="high"
+							} else {
+								if      (percentValue<=33)  newSpeed="low"
+								else if (percentValue<=66)  newSpeed="medium"
+								else if (percentValue<=100) newSpeed="high"
+								}
+                            if (device.currentValue("switch")=="off")        newSpeed="off"
+                            else if (parameter158=="1" || parameter258=="1") newSpeed="high"
+                            if (infoEnable) log.info "${device.displayName} Speed=${newSpeed}"
+                            sendEvent(name:"speed", value: "${newSpeed}")   
+                        }
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+					break
+                case 0x0001:
+                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+						if (infoEnable) log.info "${device.displayName} Remaining Time=${valueInt/10}s"
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+                    break
+                case 0x0002:
+                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+						if (infoEnable) log.info "${device.displayName} Min Level=${valueInt}s"
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+                    break
+                case 0x0003:
+                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+						if (infoEnable) log.info "${device.displayName} Max Level=${valueInt/10}s"
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+                    break
+				case 0x000F:
+                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        if (infoEnable) log.info "${device.displayName} Level Control Options: 0x${zigbee.convertToHexString(valueInt,2)}"
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+                    break
+                case 0x0010:
+                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        if (infoEnable) log.info "${device.displayName} On/Off Transition=${valueInt/10}s"
+                        state.parameter3value = valueInt
+                        device.updateSetting("parameter3",[value:"${valueInt}",type:configParams["parameter003"].type?.toString()])
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+                    break
+                case 0x0011:
+                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        valueStr = (valueInt==255?"Previous":convertByteToPercent(valueInt).toString()+"%")
+                        if (infoEnable) log.info "${device.displayName} Default On Level=$valueInt ($valueStr)"
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+                    break
+                case 0x0012:
+                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        if (infoEnable) log.info "${device.displayName} On Transition=${valueInt/10}s"
+                        state.parameter3value = valueInt
+                        state.parameter4value = valueInt
+                        device.updateSetting("parameter3",[value:"${valueInt}",type:configParams["parameter003"].type?.toString()])
+                        device.updateSetting("parameter4",[value:"${valueInt}",type:configParams["parameter004"].type?.toString()])
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+                    break
+                case 0x0013:
+                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        if (infoEnable) log.info "${device.displayName} Off Transition=${valueInt/10}s"
+                        state.parameter7value = valueInt
+                        state.parameter8value = valueInt
+                        device.updateSetting("parameter7",[value:"${valueInt}",type:configParams["parameter007"].type?.toString()])
+                        device.updateSetting("parameter8",[value:"${valueInt}",type:configParams["parameter008"].type?.toString()])
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+                    break
+                case 0x4000:
+                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        valueStr = (valueInt==255?"Previous":convertByteToPercent(valueInt).toString()+"%")
+                        if (infoEnable) log.info "${device.displayName} Power-On Level=$valueInt ($valueStr)"
+                        state.parameter15value = convertByteToPercent(valueInt)
+                        device.updateSetting("parameter15",[value:"${convertByteToPercent(valueInt)}",type:configParams["parameter015"].type?.toString()])
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+					break
+				default:
+                    if (attrInt==null && descMap.command=="0B" && descMap.direction=="01") {
+                        if (parameter51) {    //not sure why the firmware sends these when there are no bindings
+                            if (descMap.data[0]=="00" && infoEnable) log.info "${device.displayName} Bind Command Sent: Move To Level"
+                            if (descMap.data[0]=="01" && infoEnable) log.info "${device.displayName} Bind Command Sent: Move Up/Down"
+                            if (descMap.data[0]=="02" && infoEnable) log.info "${device.displayName} Bind Command Sent: Step"
+                            if (descMap.data[0]=="03" && infoEnable) log.info "${device.displayName} Bind Command Sent: Stop Level Change"
+                            if (descMap.data[0]=="04" && infoEnable) log.info "${device.displayName} Bind Command Sent: Move To Level (with On/Off)"
+                            if (descMap.data[0]=="05" && infoEnable) log.info "${device.displayName} Bind Command Sent: Move Up/Down (with On/Off)"
+                            if (descMap.data[0]=="06" && infoEnable) log.info "${device.displayName} Bind Command Sent: Step (with On/Off)"
+                        }
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
+					break
+			}
+			break
+        case 0x0013:    //ALEXA CLUSTER
+            if (traceEnable||debugEnable) traceCluster(description)
+            else if (infoEnable) log.info "${device.displayName} " + darkOrange("Alexa Heartbeat") //+ " $descMap"
+            break
+        case 0x0019:    //OTA CLUSTER
+            if (traceEnable||debugEnable) traceCluster(description)
+            else if (infoEnable) log.info "${device.displayName} " + darkOrange("OTA Cluster") //+ " $descMap"
+            switch (attrInt) {
+                case 0x0000:
+                    if (infoEnable) log.info "${device.displayName} Server ID=$valueStr"
+                    break
+                case 0x0001:
+                    if (infoEnable) log.info "${device.displayName} File Offset=$valueStr"
+                    break
+                case 0x0006:
+                    if (infoEnable) log.info "${device.displayName} Upgrade Status=$valueStr"
+                    break
+                default:
+                    log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
+                    break
+            }
+            break
+        case 0x0300:    //COLOR CONTROL CLUSTER
+            if (infoEnable||traceEnable||debugEnable) traceCluster(description)
+            break
+        case 0x0702:    //SIMPLE METERING CLUSTER
+            if (traceEnable||debugEnable) traceCluster(description)
+            switch (attrInt) {
+                case 0x0000:
+                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        float energy
+                        energy = valueInt/100
+                        if (infoEnable) log.info "${device.displayName} Energy=${energy}kWh"
+                        sendEvent(name:"energy",value:energy ,unit: "kWh")
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap		  													  
+                    break
+                default:
+                    log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
+                    break
+            }
+            break
+        case 0x0B04:    //ELECTRICAL MEASUREMENT CLUSTER
+            if (traceEnable||debugEnable) traceCluster(description)
+            switch (attrInt) {
+                case 0x0501:
+                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        float amps
+                        amps = valueInt/100
+                        if (infoEnable) log.info "${device.displayName} Amps=${amps}A"
+                        sendEvent(name:"amps",value:amps ,unit: "A")
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+                    break
+                case 0x050b:
+                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                        valueInt = Integer.parseInt(descMap['value'],16)
+                        float power 
+                        power = valueInt/10
+                        if (infoEnable) log.info "${device.displayName} Power=${power}W"
+                        sendEvent(name: "power", value: power, unit: "W")
+                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap				  																																	  
+                    break
+                default:
+                    log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
+                    break
+            }
+            break
+        case 0x8021:    //BINDING CLUSTER
+            if (infoEnable||debugEnable) log.info  "${device.displayName} " + darkOrange("Binding Cluster ") + (debugEnable?descMap:(descMap.data==null?"":"data:${descMap.data}"))
+            if (traceEnable) traceCluster(description)
+            break
+        case 0x8022:    //UNBINDING CLUSTER
+            if (infoEnable||debugEnable) log.info "${device.displayName} "+darkOrange("UNBinding Cluster ") + (debugEnable?descMap:(descMap.data==null?"":"data:${descMap.data}"))
+            if (traceEnable) traceCluster(description)
+            break
+        case 0x8032:    //ROUTING TABLE CLUSTER
+            //if (infoEnable||debugEnable) log.info "${device.displayName} "+darkOrange("Routing_Table Cluster ") + (debugEnable?descMap:"")
+            if (infoEnable||traceEnable||debugEnable) traceCluster(description)
+            break
+        case 0xfc31:    //PRIVATE CLUSTER
+            if (traceEnable||debugEnable) traceCluster(description)
+            if (attrInt == null) {
+                if (descMap.isClusterSpecific) {
+                    if (descMap.command == "00") ZigbeePrivateCommandEvent(descMap.data)        //Button Events
+                    if (descMap.command == "04") bindInitiator()                                //Start Binding
+                    if (descMap.command == "24") ZigbeePrivateLEDeffectStopEvent(descMap.data)  //LED start/stop events
+                }
+            } else if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
+                valueInt = Integer.parseInt(descMap['value'],16)
+				def valueHex = intTo32bitUnsignedHex(valueInt)
+				def infoDev = "${device.displayName} "
+				def infoTxt = "Report: P${attrInt}=${valueInt}"
+				def infoMsg = infoDev + infoTxt
+                switch (attrInt){
+                    case 0:
+                        infoMsg += " (temporarily stored level during transitions)"
+                        break
+                    case 1:
+                        infoMsg += " (Remote Dim Rate Up: " + (valueInt<127?((valueInt/10).toString()+"s)"):"default)")
+                        break
+                    case 2:
+                        infoMsg += " (Local Dim Rate Up: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 1)")
+                        break
+                    case 3:
+                        infoMsg += " (Remote Ramp Rate On: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 1)")
+                        break
+                    case 4:
+                        infoMsg += " (Local Ramp Rate On: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 3)")
+                        break
+                    case 5:
+                        infoMsg += " (Remote Dim Rate Down: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 1)")
+                        break
+                    case 6:
+                        infoMsg += " (Local Dim Rate Down: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 2)")
+                        break
+                    case 7:
+                        infoMsg += " (Remote Ramp Rate Off: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 3)")
+                        break
+                    case 8:
+                        infoMsg += " (Local  Ramp Rate Off: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 4)")
+                        break
+                    case 9:     //Min Level
+                        infoMsg += " (min level ${convertByteToPercent(valueInt)}%)"
+                        break
+                    case 10:    //Max Level
+                        infoMsg += " (max level ${convertByteToPercent(valueInt)}%)" 
+                        break
+                    case 11:    //Invert Switch
+                        infoMsg += valueInt==0?" (not Inverted)":" (Inverted)" 
+                        break
+                    case 12:    //Auto Off Timer
+                        infoMsg += " (Auto Off Timer " + (valueInt==0?red("disabled"):"${valueInt}s") + ")"
+                        break
+                    case 13:    //Default Level (local)
+                        infoMsg += " (default local level " + (valueInt==255?" = previous)":" ${convertByteToPercent(valueInt)}%)")
+						sendEvent(name:"levelPreset", value:convertByteToPercent(valueInt))
+                        break
+                    case 14:    //Default Level (remote)
+                        infoMsg += " (default remote level " + (valueInt==255?" = previous)":"${convertByteToPercent(valueInt)}%)")
+                        break
+                    case 15:    //Level After Power Restored
+                        infoMsg += " (power-on level " + (valueInt==255?" = previous)":"${convertByteToPercent(valueInt)}%)")
+                        break
+                    case 17:    //Load Level Timeout
+                        infoMsg += (valueInt==0?" (do not display load level)":(valueInt==11?" (always display load level)":"s load level timeout"))
+                        break
+                    case 18: 
+                        infoMsg += " (Active Power Report" + (valueInt==0?red(" disabled"):" ${valueInt}% change") + ")"
+                        break
+                    case 19:
+                        infoMsg += "s (Periodic Power/Energy " + (valueInt==0?red(" disabled"):"") + ")"
+                        break
+                    case 20:
+                        infoMsg += " (Active Energy Report " + (valueInt==0?red(" disabled"):" ${valueInt/100}kWh change") + ")"
+                        break
+                    case 21:    //Power Source
+                        infoMsg += (valueInt==0?red(" (Non-Neutral)"):limeGreen(" (Neutral)"))
+						sendEvent(name:"powerSource", value:valueInt==0?"Non-Neutral":"Neutral")
+                        break
+                    case 22:    //Aux Type
+                        switch (state.model?.substring(0,5)){
+							case "VZM31":    //Blue 2-in-1 Dimmer
+                            case "VZW31":    //Red  2-in-1 Dimmer
+                                infoMsg += " " + (valueInt==0?"(No Aux)":(valueInt==1?"(Dumb 3-way)":(valueInt==2?"(Smart Aux)":(valueInt==3?"(No Aux Full Wave)":"(unknown type)"))))
+								state.auxType =  (valueInt==0? "No Aux": (valueInt==1? "Dumb 3-way": (valueInt==2? "Smart Aux": (valueInt==3? "No Aux Full Wave":  "unknown type $valueInt"))))
+                                break
+                            case "VZM35":    //Fan Switch
+                                infoMsg += " " + (valueInt==0?"(No Aux)":"(Smart Aux)")
+                                state.auxType =   valueInt==0? "No Aux":  "Smart Aux"
+                                break
+                            default:
+                                infoMsg = infoDev + indianRed(infoTxt + " unknown model $state.model")
+                                state.auxType = "unknown model ${state.model}"
+                                break
+                        }
+                        break
+                    case 23:    //Quick Start (in firmware on Fan, emulated in this driver for dimmer)
+                        if  (state.model?.substring(0,5)!="VZM35") 
+                            infoMsg += " (Quick Start " + (valueInt==0?red("disabled"):"${valueInt}%") + ")"
+                        else 
+                            infoMsg += " (Quick Start " + (valueInt==0?red("disabled"):"${valueInt} seconds") + ")"
+                        break
+                    case 25:    //Higher Output in non-Neutral
+                        infoMsg += " (non-Neutral High Output " + (valueInt==0?red("disabled"):limeGreen("enabled")) + ")"
+                        break
+					case 30:	//non-Neutral AUX med gear learn value
+						infoMsg += " (non-Neutral AUX medium gear)"
+						break
+					case 31:	//non-Neutral AUX low gear learn value
+						infoMsg += " (non-Neutral AUX low gear)"
+						break
+                    case 32:    //Internal Temperature (read only)
+						valueStr = "${Math.round(valueInt*9/5+32)}°F"
+                        infoMsg += " (Internal Temp: " + hue(100-valueInt.toInteger(),"${valueStr}") + ")"
+                        sendEvent(name:"internalTemp", value:valueStr)
+                        break
+                    case 33:    //Overheat (read only)
+                        infoMsg += " (Overheat: " + (valueInt==0?limeGreen("False"):valueInt==1?red("TRUE"):"undefined") + ")"
+                        sendEvent(name:"overHeat",value:valueInt==0?"False":valueInt==1?"TRUE":"undefined")
+                        break
+                    case 50:    //Button Press Delay
+                        infoMsg += " (${valueInt*100}ms Button Delay)"
+						break
+                    case 51:    //Device Bind Number
+                        infoMsg += " (Bindings)"
+                        sendEvent(name:"numberOfBindings", value:valueInt)
+                        break
+                    case 52:    //Smart Bulb/Fan Mode
+                        if (state.model?.substring(0,5)=="VZM35") {
+                            infoMsg += " (SFM " + (valueInt==0?red("disabled)"):limeGreen("enabled)"))
+                            sendEvent(name:"smartFan", value:valueInt==0?"Disabled":"Enabled")
+						} else {
+                            infoMsg += " (SBM " + (valueInt==0?red("disabled)"):limeGreen("enabled)")) + ")"
+                            sendEvent(name:"smartBulb", value:valueInt==0?"Disabled":"Enabled")
+						}
+                        break
+                    case 53:  //Double-Tap UP
+                        infoMsg += " (Double-Tap Up " + (valueInt==0?red("disabled"):limeGreen("enabled")) + ")"
+                        break
+                    case 54:  //Double-Tap DOWN
+                        infoMsg += " (Double-Tap Down " + (valueInt==0?red("disabled"):limeGreen("enabled")) + ")"
+                        break
+                    case 55:  //Double-Tap UP level
+                        infoMsg += " (Double-Tap Up level ${convertByteToPercent(valueInt)}%)"
+                        break
+                    case 56:  //Double-Tap DOWN level
+                        infoMsg += " (Double-Tap Down level ${convertByteToPercent(valueInt)}%)"
+                        break
+					case 58:  //Exclusion Behavior
+                        infoMsg += " (Exclusion: " + (valueInt==0?"LED Bar does not pulse":valueInt==1?"LED Bar pulses blue":valueInt==2?"do not Exclude":"unknown") + ")"
+						break
+					case 59:  //Association Behavior
+                        infoMsg += " (Association: " + (valueInt==0?"None":valueInt==1?"Local":valueInt==2?"Hub":"Local+Hub") + ")"
+						break
+					case 60:
+					case 65:
+					case 70:
+					case 75:
+					case 80:
+					case 85:
+					case 90:
+					case 95:	//LED(x) color when On
+						if (valueInt<255 || attrInt==95)
+							infoMsg += " " + hue(valueInt,"(LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} color when On: ${Math.round(valueInt/255*360)}°)")
+						else
+							infoMsg +=                   " (LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} color " + hue(settings.parameter95?.toInteger(),"sync with P95") + " when On)"
+						break
+					case 61:
+					case 66:
+					case 71:
+					case 76:
+					case 81:
+					case 86:
+					case 91:
+					case 96:	//LED(x) color when Off
+						if (valueInt<255 || attrInt==96)
+							infoMsg += " " + hue(valueInt,"(LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} color when Off: ${Math.round(valueInt/255*360)}°)")
+						else
+							infoMsg +=                   " (LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} color " + hue(settings.parameter96?.toInteger(),"sync with P96") + " when Off)"
+						break
+					case 62:
+					case 67:
+					case 72:
+					case 77:
+					case 82:
+					case 87:
+					case 92:
+					case 97:	//LED(x) intensity when On
+						if (valueInt<101 || attrInt==97)
+							infoMsg += "% (LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} intensity when On)"
+						else
+							infoMsg +=  " (LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} intensity sync with P97 when On)"
+						break
+					case 63:
+					case 68:
+					case 73:
+					case 78:
+					case 83:
+					case 88:
+					case 93:
+					case 98:	//LED(x) intensity when Off
+						if (valueInt<101 || attrInt==98)
+							infoMsg += "% (LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} intensity when Off)"
+						else
+							infoMsg +=  " (LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} intensity sync with P98 when Off)"
+						break
+                    case 64:
+					case 69:
+					case 74:
+					case 79:
+					case 84:
+					case 89:
+					case 94:
+					case 99:	//LED(x) Notification [zwave]
+						def effectHex = valueHex.substring(0,2)
+						int effectInt = Integer.parseInt(effectHex,16)
+						infoMsg += " [0x${valueHex}] " + (effectInt==255?"(Stop Effect)":"(Start Effect ${effectInt})")
+						break
+					case 100:	//LED Bar Scaling
+                        infoMsg += " (LED Scaling " + (valueInt==0?blue("VZM-style"):red("LZW-style")) + ")"
+						break
+					case 123:	//Aux Switch Scenes
+                        infoMsg += " (Aux Scenes " + (valueInt==0?red("disabled"):limeGreen("enabled")) + ")"
+						break
+					case 125:	//Binding Off-to-On Sync Level
+                        infoMsg += " (Send Level with Binding " + (valueInt==0?red("disabled"):limeGreen("enabled")) + ")"
+						break
+                    case 156:    //Local Protection
+					case 256:
+                        infoMsg += " (Local Control " + (valueInt==0?limeGreen("enabled"):red("disabled")) + ")"
+                        break
+                    case 157:    //Remote Protection
+					case 257:
+                        infoMsg += " (Remote Control " + (valueInt==0?limeGreen("enabled"):red("disabled")) + ")"
+                        break
+                    case 158:    //Switch Mode
+					case 258:
+                        switch (state.model?.substring(0,5)){
+                            case "VZM31":    //Blue 2-in-1 Dimmer
+                            case "VZW31":    //Red  2-in-1 Dimmer
+                                infoMsg += " " + (valueInt==0?"(Dimmer mode)":"(On/Off mode)")
+                                sendEvent(name:"switchMode", value:valueInt==0?"Dimmer":"On/Off")
+                                break
+                            case "VZM35":    //Fan Switch
+								infoMsg += " " + (valueInt==0?"(Multi-Speed mode)":"(On/Off mode)")
+								sendEvent(name:"switchMode", value:valueInt==0?"Multi-Speed":"On/Off")
+								break
+                            default:
+                                infoMsg += " " + red(" unknown model $state.model")
+                                sendEvent(name:"switchMode", value:"unknown model")
+                                break
+                        }
+						break
+                    case 159:    //On-Off LED
+					case 259:
+                        infoMsg += " (On-Off LED mode: " + (valueInt==0?"All)":"One)")
+                        break
+					case 160:    //Firmware Update Indicator
+                    case 260:
+                        infoMsg += " (Firmware Update Indicator " + (valueInt==0?red("disabled"):limeGreen("enabled")) + ")"
+                        break
+					case 161:    //Relay Click
+                    case 261:
+                        infoMsg += " (Relay Click " + (valueInt==0?limeGreen("enabled"):red("disabled")) + ")"
+                        break
+					case 162:    //Double-Tap config button to clear notification
+                    case 262:
+                        infoMsg += " (Double-Tap config button " + (valueInt==0?limeGreen("enabled"):red("disabled")) + ")"
+                        break
+					case 163:    //LED bar display levels
+                    case 263:
+                        infoMsg += " (LED bar display levels: ${valueInt?:'full range'})"
+                        break
+                    default:
+						infoMsg += " [0x${valueInt<=0xFF?valueHex.substring(6):valueInt<=0xFFFF?valueHex.substring(4):valueHex}] " + orangeRed(bold("Undefined Parameter $attrInt"))
+                        break
+				}
+                if (infoEnable) log.info infoMsg //+ (traceEnable?" P:$attrInt V:$valueInt D:${getDefaultValue(attrInt)}":"")
+                if ((attrInt==9)
+				|| (attrInt==10)
+				|| (attrInt==13)
+				|| (attrInt==14)
+				|| (attrInt==15)
+				|| (attrInt==55)
+				|| (attrInt==56)) {
+					valueInt = convertByteToPercent(valueInt) //these attributes are stored as bytes but displayed as percentages
+				}
+                if ((attrInt==95 && parameter95custom!=null)||(attrInt==96 && parameter96custom!=null)) {   //if custom hue was set, update the custom user setting also
+                    device.updateSetting("parameter${attrInt}custom",[value:"${Math.round(valueInt/255*360)}",type:configParams["parameter${attrInt.toString().padLeft(3,"0")}"].type?.toString()])
+                    state."parameter${attrInt}custom" = Math.round(valueInt/255*360)
+                }
+				if (state.model?.substring(0,5)!="VZM35" && (attrInt==21 || attrInt==22 || attrInt==158 || attrInt==258)) {  //fan does not support leading/trailing edge dimming
+					state.dimmingMethod = "Leading Edge"							//default to Leading Edge
+					if (parameter21=="1") {											//if neutral wiring then select based on remote switch type
+						if (parameter22=="0") state.dimmingMethod = "Trailing Edge"	//no aux
+						if (parameter22=="1") state.dimmingMethod = "Leading Edge"	//dumb 3-way
+						if (parameter22=="2") state.dimmingMethod = "Trailing Edge"	//smart aux
+						if (parameter22=="3") {
+							if (parameter158=="1" || parameter258=="1") {			//Switch Mode is On-Off
+								state.dimmingMethod = "Full Wave"
+							} else {												//Switch Mode is Dimmer
+								state.dimmingMethod = "Trailing Edge"
+								device.updateSetting("parameter22",[value:"0",type:"enum"])
+								state.parameter22value=0
+							}
+						}
+					}
+					if (infoEnable||traceEnable||debugEnable) log.info "${device.displayName} Dimming Method = ${state.dimmingMethod}"
+				}
+				//Update UI setting with value received from device
+				if ((valueInt==getDefaultValue(attrInt))	//IF   value is the default
+				&& (!getReadOnlyParams().contains(attrInt))	//AND  not a read-only param
+				&& (![22,52,158,258].contains(attrInt))) {	//AND  not a key parameter
+					clearSetting(attrInt)					//THEN clear the setting (so only changed settings are displayed)
+				} else {									//ELSE update local setting
+					device.updateSetting("parameter${attrInt}",[value:"${valueInt}",type:configParams["parameter${attrInt.toString().padLeft(3,"0")}"]?.type?.toString()])
+				}
+				if (settings."parameter${attrInt}"!=null) {											//IF   device setting is not null
+					state."parameter${attrInt}value" = settings."parameter${attrInt}"?.toInteger()	//THEN set state variable to device setting
+				}
+			}
+			else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
+            break
+        default:
+            log.warn "${device.displayName} " + fireBrick("Unknown Cluster($clusterName)  ") + description
+			break
+	}
+    state.lastEventCluster =   clusterName
+    state.lastEventTime =      nowFormatted()
+    state.lastEventAttribute = attrInt
+    state.lastEventValue =     descMap.value
+    return
+}
+
+def presetLevel(value) {
+    if (infoEnable) log.info "${device.displayName} presetLevel(${value})"
+    state.lastCommandSent =                        "presetLevel(${value})"
+    state.lastCommandTime = nowFormatted()
+    def cmds = []
+    Integer scaledValue = value==null?null:Math.min(Math.max(convertPercentToByte(value.toInteger()),1),255)  //ZigBee levels range from 0x01-0xfe with 00 and ff = 'use previous'
+    cmds += setParameter(13, scaledValue)
+    cmds += setParameter(14, scaledValue)
+    if (debugEnable) log.debug "${device.displayName} preset $cmds"
+    return cmds
+}
+
+def quickStart() {
+    quickStartVariables()
+	def startLevel = device.currentValue("level").toInteger()
+	def cmds= []
+	if (settings.parameter23?.toInteger()>0 ) {          //only do quickStart if enabled
+		if (infoEnable) log.info "${device.displayName} quickStart(" + (state.model?.substring(0,5)!="VZM35"?"${settings.parameter23}%)":"${settings.parameter23}s)")
+		if (state.model?.substring(0,5)!="VZM35") {      //IF not the Fan switch THEN emulate quickStart 
+			if (startLevel<state.parameter23value) cmds += zigbee.setLevel(state.parameter23value?.toInteger(),0,34)  //only do quickStart if currentLevel is < Quick Start Level (34ms is two sinewave cycles)
+			cmds += zigbee.setLevel(startLevel,0,longDelay) 
+			if (debugEnable) log.debug "${device.displayName} quickStart $cmds"
+		}
+	}
+    return cmds
+}
+
+def quickStartVariables() {
+    if (state.model?.substring(0,5)!="VZM35") {  //IF not the Fan switch THEN set the quickStart variables manually
+        settings.parameter23 =  (settings.parameter23!=null?settings.parameter23:getDefaultValue(23))
+        state.parameter23value = Math.round((settings.parameter23?:0).toFloat())
+        //state.parameter23level = Math.round((settings.parameter23level?:defaultQuickLevel).toFloat())
+    }
+}
+
+def readDeviceAttributes() {
+	if (traceEnable||debugEnable) log.trace "${device.displayName} readDeviceAttributes()"
+	def cmds = []
+//	cmds += zigbee.readAttribute(0x0000, 0x0000, [:], shortDelay)    //BASIC ZCL Version
+//	cmds += zigbee.readAttribute(0x0000, 0x0001, [:], shortDelay)    //BASIC Application Version
+//	cmds += zigbee.readAttribute(0x0000, 0x0002, [:], shortDelay)    //BASIC Stack Version
+//	cmds += zigbee.readAttribute(0x0000, 0x0003, [:], shortDelay)    //BASIC HW Version
+//	cmds += zigbee.readAttribute(0x0000, 0x0004, [:], shortDelay)    //BASIC Manufacturer Name
+	cmds += zigbee.readAttribute(0x0000, 0x0005, [:], shortDelay)    //BASIC Model
+	cmds += zigbee.readAttribute(0x0000, 0x0006, [:], shortDelay)    //BASIC SW Date Code
+//	cmds += zigbee.readAttribute(0x0000, 0x0007, [:], shortDelay)    //BASIC Power Source
+//	cmds += zigbee.readAttribute(0x0000, 0x0008, [:], shortDelay)    //BASIC GenericDevice-Class
+//	cmds += zigbee.readAttribute(0x0000, 0x0009, [:], shortDelay)    //BASIC GenericDevice-Type
+//	cmds += zigbee.readAttribute(0x0000, 0x000A, [:], shortDelay)    //BASIC ProductCode
+//	cmds += zigbee.readAttribute(0x0000, 0x000B, [:], shortDelay)    //BASIC ProductURL
+//	cmds += zigbee.readAttribute(0x0000, 0x000C, [:], shortDelay)    //BASIC ManufacturerVersionDetails
+//	cmds += zigbee.readAttribute(0x0000, 0x000D, [:], shortDelay)    //BASIC SerialNumber
+//	cmds += zigbee.readAttribute(0x0000, 0x000E, [:], shortDelay)    //BASIC ProductLabel
+//	cmds += zigbee.readAttribute(0x0000, 0x0010, [:], shortDelay)    //BASIC LocationDescription
+//	cmds += zigbee.readAttribute(0x0000, 0x0011, [:], shortDelay)    //BASIC PhysicalEnvironment
+//	cmds += zigbee.readAttribute(0x0000, 0x0012, [:], shortDelay)    //BASIC DeviceEnabled
+//	cmds += zigbee.readAttribute(0x0000, 0x0013, [:], shortDelay)    //BASIC AlarmMask
+//	cmds += zigbee.readAttribute(0x0000, 0x0014, [:], shortDelay)    //BASIC DisableLocalConfig
+	cmds += zigbee.readAttribute(0x0000, 0x4000, [:], shortDelay)    //BASIC SWBuildID
+//	cmds += zigbee.readAttribute(0x0003, 0x0000, [:], shortDelay)    //IDENTIFY Identify Time
+//	cmds += zigbee.readAttribute(0x0004, 0x0000, [:], shortDelay)    //GROUP Name Support
+//	cmds += zigbee.readAttribute(0x0005, 0x0000, [:], shortDelay)    //SCENES Scene Count
+//	cmds += zigbee.readAttribute(0x0005, 0x0001, [:], shortDelay)    //SCENES Current Scene
+//	cmds += zigbee.readAttribute(0x0005, 0x0002, [:], shortDelay)    //SCENES Current Group
+//	cmds += zigbee.readAttribute(0x0005, 0x0003, [:], shortDelay)    //SCENES Scene Valid
+//	cmds += zigbee.readAttribute(0x0005, 0x0004, [:], shortDelay)    //SCENES Name Support
+//	cmds += zigbee.readAttribute(0x0005, 0x0005, [:], shortDelay)    //SCENES LastConfiguredBy
+	cmds += zigbee.readAttribute(0x0006, 0x0000, [:], shortDelay)    //ON_OFF Current OnOff state
+//	cmds += zigbee.readAttribute(0x0006, 0x4000, [:], shortDelay)    //ON_OFF GlobalSceneControl
+//	cmds += zigbee.readAttribute(0x0006, 0x4001, [:], shortDelay)    //ON_OFF OnTime
+//	cmds += zigbee.readAttribute(0x0006, 0x4002, [:], shortDelay)    //ON_OFF OffWaitTime
+	cmds += zigbee.readAttribute(0x0006, 0x4003, [:], shortDelay)    //ON_OFF Startup OnOff state
+	cmds += zigbee.readAttribute(0x0008, 0x0000, [:], shortDelay)    //LEVEL_CONTROL CurrentLevel
+//	cmds += zigbee.readAttribute(0x0008, 0x0001, [:], shortDelay)    //LEVEL_CONTROL RemainingTime
+//	cmds += zigbee.readAttribute(0x0008, 0x0002, [:], shortDelay)    //LEVEL_CONTROL MinLevel
+//	cmds += zigbee.readAttribute(0x0008, 0x0003, [:], shortDelay)    //LEVEL_CONTROL MaxLevel
+//	cmds += zigbee.readAttribute(0x0008, 0x0004, [:], shortDelay)    //LEVEL_CONTROL CurrentFrequency
+//	cmds += zigbee.readAttribute(0x0008, 0x0005, [:], shortDelay)    //LEVEL_CONTROL MinFrequency
+//	cmds += zigbee.readAttribute(0x0008, 0x0006, [:], shortDelay)    //LEVEL_CONTROL MaxFrequency
+//	cmds += zigbee.readAttribute(0x0008, 0x000F, [:], shortDelay)    //LEVEL_CONTROL Options
+//	cmds += zigbee.readAttribute(0x0008, 0x0010, [:], shortDelay)    //LEVEL_CONTROL OnOff Transition Time
+//	cmds += zigbee.readAttribute(0x0008, 0x0011, [:], shortDelay)    //LEVEL_CONTROL OnLevel
+//  cmds += zigbee.readAttribute(0x0008, 0x0012, [:], shortDelay)    //LEVEL_CONTROL OnTransitionTime
+//  cmds += zigbee.readAttribute(0x0008, 0x0013, [:], shortDelay)    //LEVEL_CONTROL OffTransitionTime
+//  cmds += zigbee.readAttribute(0x0008, 0x0014, [:], shortDelay)    //LEVEL_CONTROL DefaultMoveRate
+//  cmds += zigbee.readAttribute(0x0008, 0x4000, [:], shortDelay)    //LEVEL_CONTROL StartUpCurrentLevel
+//  cmds += zigbee.readAttribute(0x0019, 0x0000, [:], shortDelay)    //OTA Upgrade Server ID
+//  cmds += zigbee.readAttribute(0x0019, 0x0001, [:], shortDelay)    //OTA File Offset
+//  cmds += zigbee.readAttribute(0x0019, 0x0002, [:], shortDelay)    //OTA CurrentFileVersion
+//  cmds += zigbee.readAttribute(0x0019, 0x0003, [:], shortDelay)    //OTA CurrentZigBeeStackVersion
+//  cmds += zigbee.readAttribute(0x0019, 0x0004, [:], shortDelay)    //OTA DownloadedFileVersion
+//  cmds += zigbee.readAttribute(0x0019, 0x0005, [:], shortDelay)    //OTA DownloadedZigBeeStackVersion
+//  cmds += zigbee.readAttribute(0x0019, 0x0006, [:], shortDelay)    //OTA Image Upgrade Status
+//  cmds += zigbee.readAttribute(0x0019, 0x0007, [:], shortDelay)    //OTA ManufacturerID 
+//  cmds += zigbee.readAttribute(0x0019, 0x0008, [:], shortDelay)    //OTA Image TypeID 
+//  cmds += zigbee.readAttribute(0x0019, 0x0009, [:], shortDelay)    //OTA MinimumBlockPeriod
+//  cmds += zigbee.readAttribute(0x0019, 0x000A, [:], shortDelay)    //OTA Image Stamp
+//  cmds += zigbee.readAttribute(0x0019, 0x000B, [:], shortDelay)    //OTA UpgradeActivationPolicy
+//  cmds += zigbee.readAttribute(0x0019, 0x000C, [:], shortDelay)    //OTA UpgradeTimeoutPolicy 
+    if (state.model?.substring(0,5)!="VZM35")	//Fan does not support power/energy reports
+      cmds += zigbee.readAttribute(0x0702, 0x0000, [:], shortDelay)  //SIMPLE_METERING Energy Report
+//  cmds += zigbee.readAttribute(0x0702, 0x0200, [:], shortDelay)    //SIMPLE_METERING Status
+//  cmds += zigbee.readAttribute(0x0702, 0x0300, [:], shortDelay)    //SIMPLE_METERING Units
+//  cmds += zigbee.readAttribute(0x0702, 0x0301, [:], shortDelay)    //SIMPLE_METERING AC Multiplier
+//  cmds += zigbee.readAttribute(0x0702, 0x0302, [:], shortDelay)    //SIMPLE_METERING AC Divisor
+//  cmds += zigbee.readAttribute(0x0702, 0x0303, [:], shortDelay)    //SIMPLE_METERING Formatting
+//  cmds += zigbee.readAttribute(0x0702, 0x0306, [:], shortDelay)    //SIMPLE_METERING Metering Device Type
+//  cmds += zigbee.readAttribute(0x0B04, 0x0501, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Line Current
+//  cmds += zigbee.readAttribute(0x0B04, 0x0502, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Active Current
+//  cmds += zigbee.readAttribute(0x0B04, 0x0503, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Reactive Current
+//  cmds += zigbee.readAttribute(0x0B04, 0x0505, [:], shortDelay)    //ELECTRICAL_MEASUREMENT RMS Voltage
+//  cmds += zigbee.readAttribute(0x0B04, 0x0506, [:], shortDelay)    //ELECTRICAL_MEASUREMENT RMS Voltage min
+//  cmds += zigbee.readAttribute(0x0B04, 0x0507, [:], shortDelay)    //ELECTRICAL_MEASUREMENT RMS Voltage max
+//  cmds += zigbee.readAttribute(0x0B04, 0x0508, [:], shortDelay)    //ELECTRICAL_MEASUREMENT RMS Current
+//  cmds += zigbee.readAttribute(0x0B04, 0x0509, [:], shortDelay)    //ELECTRICAL_MEASUREMENT RMS Current min
+//  cmds += zigbee.readAttribute(0x0B04, 0x050A, [:], shortDelay)    //ELECTRICAL_MEASUREMENT RMS Current max
+    if (state.model?.substring(0,5)!="VZM35")  //Fan does not support power/energy reports
+      cmds += zigbee.readAttribute(0x0B04, 0x050B, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Active Power
+//  cmds += zigbee.readAttribute(0x0B04, 0x050C, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Active Power min
+//  cmds += zigbee.readAttribute(0x0B04, 0x050D, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Active Power max
+//  cmds += zigbee.readAttribute(0x0B04, 0x050E, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Reactive Power
+//  cmds += zigbee.readAttribute(0x0B04, 0x050F, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Apparent Power
+//  cmds += zigbee.readAttribute(0x0B04, 0x0510, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Power Factor
+//  cmds += zigbee.readAttribute(0x0B04, 0x0604, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Power Multiplier
+//  cmds += zigbee.readAttribute(0x0B04, 0x0605, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Power Divisor
+//  cmds += zigbee.readAttribute(0x8021, 0x0000, [:], shortDelay)    //Binding
+//  cmds += zigbee.readAttribute(0x8022, 0x0000, [:], shortDelay)    //UnBinding
+	return cmds
+}
+
+def refresh(option) {
+    option = (option==null||option==" ")?"":option
+    if (infoEnable) log.info "${device.displayName} refresh(${option})"
+    state.lastCommandSent =                        "refresh(${option})"
+    state.lastCommandTime = nowFormatted()
+    state.driverDate = getDriverDate()
+	state.model = device.getDataValue('model')
+    if (infoEnable||traceEnable||debugEnable) log.info "${device.displayName} Driver Date $state.driverDate"
+    def cmds = []
+	cmds += readDeviceAttributes()
+	configParams.each {	//loop through all parameters
+		int i = it.value.number.toInteger()
+		if (i==23 && (state.model?.substring(0,5)!="VZM35")) quickStartVariables()  //quickStart is implemented in firmware for the fan, emulated in this driver for 2-in-1 Dimmer
+
+		switch (option) {
+			case "":									//option is blank or null 
+				if (([22,52,158,258].contains(i))		//refresh primary settings
+				|| (getReadOnlyParams().contains(i))	//refresh read-only params
+				|| (settings."parameter${i}"!=null)) {	//refresh user settings
+					cmds += getParameter(i)
+				}
+				break
+			case "All":
+				cmds += getParameter(i) //if option is All then refresh all params
+				break
+			default: 
+				if (traceEnable||debugEnable) log.error "${device.displayName} Unknonwn option 'refresh($option)'"
+				break
+		}
+    }
+	return cmds
+}
+
+def remoteControl(option) {
+    if (infoEnable) log.info "${device.displayName} remoteControl($option)"
+    state.lastCommandSent =                        "remoteControl($option)"
+    state.lastCommandTime = nowFormatted()
+    def cmds = []
+    cmds += zigbee.command(0xfc31,0x10,["mfgCode":"0x122F"],shortDelay,"${option=="Disabled"?"01":"00"}")
+    if (debugEnable) log.debug "${device.displayName} remoteControl $cmds"
+	return cmds 
+}
+
+def resetEnergyMeter() {
+    if (infoEnable) log.info "${device.displayName} resetEnergyMeter(" + device.currentValue("energy") + "kWh)"
+    state.lastCommandSent =                        "resetEnergyMeter(" + device.currentValue("energy") + "kWh)"
+    state.lastCommandTime = nowFormatted()
+    def cmds = []
+    cmds += zigbee.command(0xfc31,0x02,["mfgCode":"0x122F"],shortDelay,"0")
+    cmds += zigbee.readAttribute(CLUSTER_SIMPLE_METERING, 0x0000)
+    if (debugEnable) log.debug "${device.displayName} resetEnergyMeter $cmds"
+    return cmds 
+}
+        
+def setAttribute(Integer cluster, Integer attrInt, Integer dataType, Integer value, Map additionalParams = [:], Integer delay=shortDelay) {
+    if (cluster==0xfc31) additionalParams = ["mfgCode":"0x122F"]
+    if (delay==null||delay==0) delay = shortDelay
+    def infoMsg = "${device.displayName} Set " + clusterLookup(cluster)
+    if (cluster==0xfc31) {
+        infoMsg += " attribute ${attrInt} dataType 0x${zigbee.convertToHexString(dataType,2)} value "
+        switch (attrInt) {
+			case 9:     //Min Level
+			case 10:    //Max Level
+			case 13:    //Default Level (local)
+			case 14:    //Default Level (remote)
+			case 15:    //Level after power restored
+			case 55:	//Double-Tap UP Level
+			case 56:	//Double-Tap DOWN Level
+                infoMsg += "${value} = ${convertByteToPercent(value)}% on 255 scale"
+                break
+            case 23:
+                quickStartVariables()
+                infoMsg = ""
+                break
+			case 60:	//LED1 color when on
+			case 61:	//LED1 color when off
+			case 65:	//LED2 color when on
+			case 66:	//LED2 color when off
+			case 70:	//LED3 color when on
+			case 71:	//LED3 color when off
+			case 75:	//LED4 color when on
+			case 76:	//LED4 color when off
+			case 80:	//LED5 color when on
+			case 81:	//LED5 color when off
+			case 85:	//LED6 color when on
+			case 86:	//LED6 color when off
+			case 90:	//LED7 color when on
+			case 91:	//LED7 color when off
+            case 95:	//LED bar color when on
+            case 96:	//LED bar color when off
+                infoMsg += "${value} = ${Math.round(value/255*360)}° on 360° scale"
+                break
+            default:
+                infoMsg += "${value}"
+                break 
+        }
+    } else {
+        infoMsg += " attribute 0x${zigbee.convertToHexString(attrInt,4)} value ${value}"
+    }
+    if (traceEnable) log.trace infoMsg + (delay==shortDelay?"":" [delay ${delay}]")
+    def cmds = zigbee.writeAttribute(cluster, attrInt, dataType, value, additionalParams, delay)
+    if (debugEnable) log.debug "${device.displayName} setAttribute $cmds"
+    return cmds
+}
+
+def getAttribute(Integer cluster, Integer attrInt=0, Map additionalParams = [:], Integer delay=shortDelay) {
+    if (cluster==0xfc31) additionalParams = ["mfgCode":"0x122F"]
+    if (delay==null||delay==0) delay = shortDelay
+    if (debugEnable) log.debug  "${device.displayName} Get "+clusterLookup(cluster)+" attribute ${attrInt}"+(delay==shortDelay?"":" [delay ${delay}]")
+    if (cluster==0xfc31 && attrInt==23 && state.model?.substring(0,5)!="VZM35") {  //if not Fan, get the quickStart values from state variables since dimmer does not store these
+		if (infoEnable) log.info "${device.displayName} Report: P${attrInt}=${state?.parameter23value} (QuickStart " + (state.parameter23value?.toInteger()==0?red("disabled"):"${state.parameter23value?.toInteger()}" + state.model?.substring(0,5)!="VZM35"?"${settings.parameter23}%":"${settings.parameter23}s") + ")"
+		if (infoEnable) log.info "${device.displayName} Report: P${attrInt} level=${state?.parameter23level} (QuickStart startup level)"
+		if (settings.parameter23level?.toInteger()==defaultQuickLevel) device.removeSetting("parameter23level") 
+    }
+	def cmds = []
+    cmds += zigbee.readAttribute(cluster, attrInt, additionalParams, delay)
+	if (debugEnable) log.debug "${device.displayName} getAttribute $cmds"
+    return cmds
+}
+
+def setLevel(value, duration=0xFFFF) {
+	if (duration==null) duration=0xFFFF
+    if (infoEnable) log.info "${device.displayName} setLevel($value" + (duration==0xFFFF?")":", ${duration}s)")
+    state.lastCommandSent =                        "setLevel($value" + (duration==0xFFFF?")":", ${duration}s)")
+    state.lastCommandTime = nowFormatted()
+    if (duration!=0xFFFF) duration = duration.toInteger()*10  //firmware duration in 10ths
+    def cmds = []
+    cmds += zigbee.setLevel(value.toInteger(),duration,shortDelay)
+    if (debugEnable) log.debug "${device.displayName} setLevel $cmds"
+	return cmds
+}
+
+def setParameter(paramNum=0, value=null, size=null, delay=shortDelay) {
+	paramNum = paramNum?.toInteger()
+	value    = value?.toInteger()
+	size     = size?.toInteger()
+	if (size==null || size==" ") size = configParams["parameter${paramNum.toString().padLeft(3,'0')}"]?.size?:8
+	if (traceEnable) log.trace "${device.displayName} setParameter($paramNum, $value, $size)"
+	state.lastCommandSent =                          "setParameter($paramNum, $value, $size)"
+	state.lastCommandTime = nowFormatted()
+	def cmds = []
+    size = calculateSize(size).toInteger()
+    if (value!=null) cmds += setAttribute(0xfc31,paramNum,size,value)	//no value means we only want to GET the value
+	if (paramNum==52 || paramNum==158 || paramNum==258) cmds += "delay $longDelay"	//allow extra time when changing modes
+    cmds += getAttribute(0xfc31, paramNum, [:], delay)
+    if (debugEnable) log.debug value!=null?"${device.displayName} setParameter $cmds":"${device.displayName} getParameter $cmds"
+    return cmds
+}
+
+def getParameter(paramNum=0, delay=shortDelay) {
+	paramNum = paramNum?.toInteger()
+    if (traceEnable) log.trace "${device.displayName} getParameter($paramNum,$delay)"
+    //state.lastCommandSent =                        "getParameter($paramNum,$delay)"
+    //state.lastCommandTime = nowFormatted() //this is not a custom command.  Only use state variable for commands on the device details page
+    def cmds = []
+	if (paramNum<0) {	//special case, if negative then read all params from 0-max (for debugging)
+		for(int i = 0;i<=(getParameterNumbers()+getReadOnlyParams()).max();i++) {
+			cmds += getAttribute(0xfc31, i, [:], 100)	//override shortDelay with very short (100ms) delay
+		}	
+	} else {	//otherwise, just get the requested parameter
+		cmds += getAttribute(0xfc31, paramNum, [:], delay)
+	}
+    if (debugEnable) log.debug "${device.displayName} getParameter $cmds"
+    return cmds
+}
+
+def setPrivateCluster(attributeId, value, size=8) {	//for backward compatibility
+	log.warn "${device.displayName} setPrivateCluster(${red(italic(bold('command is depreciated. Use setParameter instead')))})"
+    return setParameter(attributeId, value, size.toInteger())
+}
+
+def setSpeed(value) {  // FOR FAN ONLY
+    if (infoEnable) log.info "${device.displayName} setSpeed(${value})"
+    state.lastCommandSent =                        "setSpeed(${value})"
+    state.lastCommandTime = nowFormatted()
+	def currentLevel = device.currentValue("level")==null?0:device.currentValue("level").toInteger()
+	if (device.currentValue("switch")=="off") currentLevel = 0
+	boolean smartMode = device.currentValue("smartFan")=="Enabled"
+	def newLevel = 0
+    def cmds = []
+    switch (value) {
+        case "off":
+            cmds += zigbee.off(shortDelay) 
+            break
+        case "low": 
+            cmds += zigbee.setLevel(smartMode?20:33) 
+            break
+        case "medium-low":             //placeholder since Hubitat natively supports 5-speed fans
+            cmds += zigbee.setLevel(40) 
+            break
+        case "medium": 
+            cmds += zigbee.setLevel(smartMode?60:66) 
+            break
+        case "medium-high":            //placeholder since Hubitat natively supports 5-speed fans
+            cmds += zigbee.setLevel(80) 
+            break
+        case "high": 
+            cmds += zigbee.setLevel(100) 
+            break
+        case "on":
+            cmds += zigbee.on(shortDelay)
+            break
+		case "up":
+			if      (currentLevel<=0 )  {newLevel=20}
+			else if (currentLevel<=20)  {newLevel=smartMode?40:60}
+			else if (currentLevel<=40)  {newLevel=60}
+			else if (currentLevel<=60)  {newLevel=smartMode?80:100}
+			else if (currentLevel<=100) {newLevel=100}
+            cmds += zigbee.setLevel(newLevel)
+			break
+		case "down":
+			if      (currentLevel>80) {newLevel=smartMode?80:60}
+			else if (currentLevel>60) {newLevel=60}
+			else if (currentLevel>40) {newLevel=smartMode?40:20}
+			else if (currentLevel>20) {newLevel=20}
+			else if (currentLevel>0)  {newLevel=currentLevel}
+            cmds += zigbee.setLevel(newLevel)
+			break
+    }
+    if (debugEnable) log.debug "${device.displayName} setSpeed $cmds"
+    return cmds
+}
+
+def setZigbeeAttribute(cluster, attributeId, value, size) {
+    if (traceEnable) log.trace value!=null?"${device.displayName} setZigbeeAttribute(${cluster}, ${attributeId}, ${value}, ${size})":"${device.displayName} getZigbeeAttribute(${cluster}, ${attributeId})"
+    state.lastCommandSent =    value!=null?                      "setZigbeeAttribute(${cluster}, ${attributeId}, ${value}, ${size})":                      "getZigbeeAttribute(${cluster}, ${attributeId})"
+    state.lastCommandTime = nowFormatted()
+    def cmds = []
+    Integer setCluster = cluster.toInteger()
+    Integer attId = attributeId.toInteger()
+    Integer attValue = (value?:0).toInteger()
+    Integer attSize = calculateSize(size).toInteger()
+    if (value!=null) cmds += setAttribute(setCluster,attId,attSize,attValue,[:],attId==258?longDelay:shortDelay)
+    cmds += getAttribute(setCluster, attId)
+    if (debugEnable) log.debug "${device.displayName} setZigbeeAttribute $cmds"
+    return cmds
+}
+
+def startLevelChange(direction, duration=null) {
+    def newLevel = direction=="up"?100:device.currentValue("switch")=="off"?0:1
+	duration = duration!=null?duration:(calculateParameter(1)/10)
+    if (infoEnable) log.info "${device.displayName} startLevelChange(${direction}" + (duration==null?")":", ${duration}s)")
+    state.lastCommandSent =                        "startLevelChange(${direction}" + (duration==null?")":", ${duration}s)")
+    state.lastCommandTime = nowFormatted()
+	def cmds = []
+    cmds += duration==null?zigbee.setLevel(newLevel):zigbee.setLevel(newLevel, duration.toInteger()*10)
+    if (debugEnable) log.debug "${device.displayName} startLevelChange $cmds"
+	return cmds
+}
+
+def stopLevelChange() {
+    if (infoEnable) log.info "${device.displayName} stopLevelChange()" // at level " + device.currentValue("level")
+    state.lastCommandSent =                        "stopLevelChange()"
+    state.lastCommandTime = nowFormatted()
+	def cmds = []
+    cmds += ["he cmd 0x${device.deviceNetworkId} 0x${device.endpointId} ${CLUSTER_LEVEL_CONTROL} ${COMMAND_STOP} {}","delay $shortDelay"]
+    if (debugEnable) log.debug "${device.displayName} stopLevelChange $cmds"
+    return cmds
+}
+
+def toggle() {	
+    def toggleDirection = device.currentValue("switch")=="off"?"off->on":"on->off"
+    if (infoEnable) log.info "${device.displayName} toggle(${toggleDirection})"
+    state.lastCommandSent =                        "toggle(${toggleDirection})"
+    state.lastCommandTime = nowFormatted()
+    def cmds = []
+    cmds += zigbee.command(CLUSTER_ON_OFF, COMMAND_TOGGLE)
+    //// if having trouble keeping multiple bulbs in sync then comment-out the toggle command
+	//// and use the below code to emulate toggle with on/off commands
+    //if (device.currentValue("switch")=="off") {
+	//	if (settings.parameter23?.toInteger()>0) {
+	//		cmds += quickStart()  //IF quickStart is enabled THEN quickStart
+	//	} else {
+	//		cmds += zigbee.on(shortDelay)
+	//	}
+	//} else {
+	//	cmds += zigbee.off(shortDelay)
+	//}
+    if (debugEnable) log.debug "${device.displayName} toggle $cmds"
+    return cmds
+}
+
+def updated(option) { // called when "Save Preferences" is requested
+    option = (option==null||option==" ")?"":option
+    if (infoEnable) log.info "${device.displayName} updated(${option})"
+    state.lastCommandSent =                        "updated(${option})"
+    state.lastCommandTime = nowFormatted()
+    def cmds = []
+    def nothingChanged = true
+    int defaultValue
+    int newValue
+	configParams.each {	//loop through all parameters
+		int i = it.value.number.toInteger()
+		newValue = calculateParameter(i)
+		defaultValue=getDefaultValue(i)
+		if ([9,10,13,14,15,55,56].contains(i)) defaultValue=convertPercentToByte(defaultValue) //convert percent values back to byte values
+		if ((i==95 && parameter95custom!=null)||(i==96 && parameter96custom!=null)) {                                         //IF   a custom hue value is set
+			if ((Math.round(settings?."parameter${i}custom"?.toInteger()/360*255)==settings?."parameter${i}"?.toInteger())) { //AND  custom setting is same as normal setting
+				device.removeSetting("parameter${i}custom")                                                                   //THEN clear custom hue and use normal color 
+				if (infoEnable||traceEnable||debugEnable) log.info "${device.displayName} Cleared Custom Hue setting since it equals standard color setting"
+			}
+		}
+		switch (option) {
+			case "":
+				if ((getParameterNumbers().contains(i))		//IF   this is a valid parameter for this device mode
+				&& (settings."parameter$i"!=null)			//AND  this is a non-default setting
+				&& (!getReadOnlyParams().contains(i))) {	//AND  this is not a read-only parameter
+					cmds += setParameter(i, newValue)		//THEN set the new value
+					nothingChanged = false
+				}
+				break
+			case "All":
+			case "Default":
+				if (option=="Default") newValue = defaultValue	//if user selected "Default" then set the new value to the default value
+				if (((i!=158)&&(i!=258))					//IF   we are not changing Switch Mode
+				&& (!getReadOnlyParams().contains(i))) {	//AND  this is not a read-only parameter
+					cmds += setParameter(i, newValue)		//THEN Set the new value
+					nothingChanged = false
+				} else {									//ELSE this is a read-only parameter or Switch Mode parameter
+					cmds += getParameter(i)					//so Get current value from device
+				}
+				break
+			default: 
+				if (traceEnable||debugEnable) log.error "${device.displayName} Unknown option 'updated($option)'"
+				break
+		}
+        if ((i==23)&&(state.model?.substring(0,5)!="VZM35")) {  //IF not Fan switch THEN manually update the quickStart state variables since Dimmer does not store these
+            quickStartVariables()
+		}
+    }
+    if (settings?.groupBinding1 && !state?.groupBinding1) {
+        bindGroup("bind",settings.groupBinding1?.toInteger())
+		//device.updateSetting("groupBinding1",[value:settings.groupBinding1?.toInteger(),type:"number"])
+		state.groupBinding1=settings.groupBinding1?.toInteger()
+        nothingChanged = false
+    } else {
+        if (!settings?.groupBinding1 && state?.groupBinding1) {
+            bindGroup("unbind",state.groupBinding1?.toInteger())
+			device.removeSetting("groupBinding1")
+			state.groupBinding1=null
+            nothingChanged = false
+        }
+    }
+    if (settings?.groupBinding2 && !state?.groupBinding2) {
+        bindGroup("bind",settings.groupBinding2?.toInteger())
+		//device.updateSetting("groupBinding2",[value:settings.groupBinding2?.toInteger(),type:"number"])
+		state.groupBinding2=settings.groupBinding2?.toInteger()
+        nothingChanged = false
+    } else {
+        if (!settings?.groupBinding2 && state?.groupBinding2) {
+            bindGroup("unbind",state.groupBinding2?.toInteger())
+			device.removeSetting("groupBinding2")
+			state.groupBinding2=null
+            nothingChanged = false
+        }
+    }
+    if (settings?.groupBinding3 && !state?.groupBinding3) {
+        bindGroup("bind",settings.groupBinding3?.toInteger())
+		//device.updateSetting("groupBinding3",[value:state.groupBinding3?.toInteger(),type:"number"])
+		state.groupBinding3=state.groupBinding3?.toInteger()
+        nothingChanged = false
+    } else {
+        if (!settings?.groupBinding3 && state?.groupBinding3) {
+            bindGroup("unbind",state.groupBinding3?.toInteger())
+			device.removeSetting("groupBinding3")
+			state.groupBinding3=null
+            nothingChanged = false
+        }
+    }
+	// remove duplicate groups
+	if (settings.groupBinding3!=null && settings.groupBinding3==settings.groupBinding2) {device.removeSetting("groupBinding3"); state.groupBinding3 = null; if (infoEnable) log.info "${device.displayName} Removed duplicate Group Bind #3"}
+	if (settings.groupBinding2!=null && settings.groupBinding2==settings.groupBinding1) {device.removeSetting("groupBinding2"); state.groupBinding2 = null; if (infoEnable) log.info "${device.displayName} Removed duplicate Group Bind #2"}
+	if (settings.groupBinding1!=null && settings.groupBinding1==settings.groupBinding3) {device.removeSetting("groupBinding3"); state.groupBinding3 = null; if (infoEnable) log.info "${device.displayName} Removed duplicate Group Bind #3"}
+	
+    if (nothingChanged && (infoEnable||traceEnable||debugEnable)) log.info "${device.displayName} No DEVICE settings were changed"
+	log.info  "${device.displayName} Info logging  " + (infoEnable?limeGreen("Enabled"):red("Disabled"))
+	log.trace "${device.displayName} Trace logging " + (traceEnable?limeGreen("Enabled"):red("Disabled"))
+	log.debug "${device.displayName} Debug logging " + (debugEnable?limeGreen("Enabled"):red("Disabled"))
+
+    if (infoEnable && disableInfoLogging) {
+		log.info "${device.displayName} Info Logging will be disabled in $disableInfoLogging minutes"
+		runIn(disableInfoLogging*60,infoLogsOff)
+	}
+    if (traceEnable && disableTraceLogging) {
+		log.trace "${device.displayName} Trace Logging will be disabled in $disableTraceLogging minutes"
+		runIn(disableTraceLogging*60,traceLogsOff)
+	}
+    if (debugEnable && disableDebugLogging) {
+		log.debug "${device.displayName} Debug Logging will be disabled in $disableDebugLogging minutes"
+		runIn(disableDebugLogging*60,debugLogsOff) 
+	}
+    return cmds
+}
+
+List updateFirmware() {
+    if (infoEnable) log.info "${device.displayName} updateFirmware(switch's fwDate: ${state.fwDate}, switch's fwVersion: ${state.fwVersion})"
+    state.lastCommandSent =                        "updateFirmware()"
+    state.lastCommandTime = nowFormatted()
+    def cmds = []
+    //if (state?.lastUpdateFw && now() - state.lastUpdateFw < 2000) {
+	//	state.remove("lastUpdateFw")
+        cmds += zigbee.updateFirmware()
+        if (debugEnable) log.debug "${device.displayName} updateFirmware $cmds"
+    //} else {
+    //    log.warn "Firmware in this channel may be \"beta\" quality. Please check https://community.inovelli.com/t/blue-series-2-1-firmware-changelog-vzm31-sn/12326 before proceeding. Double-click \"Update Firmware\" to proceed"
+	//	state.lastUpdateFw = now()
+	//	runIn(2,lastUpdateFwRemove)
+    //}
+    return cmds
+}
+//def lastUpdateFwRemove() {if (state?.lastUpdateFw) state.remove("lastUpdateFw")}
+
+void ZigbeePrivateCommandEvent(data) {
+    if (infoEnable) log.info "${device.displayName} SceneButton=${data[0]} ButtonAttributes=${data[1]}"
+    Integer ButtonNumber = Integer.parseInt(data[0],16)
+    Integer ButtonAttributes = Integer.parseInt(data[1],16)
+    switch(zigbee.convertToHexString(ButtonNumber,2) + zigbee.convertToHexString(ButtonAttributes,2)) {
+        case "0200":    //Tap Up 1x
+            //if (state.model?.substring(0,5)!="VZM35") quickStart()  //If not Fan then emulate quickStart for local button push (this doesn't appear to work - not sure why)
+            buttonEvent(1, "pushed", "physical")
+            break
+        case "0203":    //Tap Up 2x
+            buttonEvent(2, "pushed", "physical")
+            break
+        case "0204":    //Tap Up 3x
+            buttonEvent(3, "pushed", "physical")
+            break
+        case "0205":    //Tap Up 4x
+            buttonEvent(4, "pushed", "physical")
+            break
+        case "0206":    //Tap Up 5x
+            buttonEvent(5, "pushed", "physical")
+            break
+        case "0202":    //Hold Up
+            buttonEvent(6, "pushed", "physical")
+            break
+        case "0201":    //Release Up
+            buttonEvent(7, "pushed", "physical")
+            break
+        case "0100":    //Tap Down 1x
+            buttonEvent(1, "held", "physical")
+            break
+        case "0103":    //Tap Down 2x
+            buttonEvent(2, "held", "physical")
+            break
+        case "0104":    //Tap Down 3x
+            buttonEvent(3, "held", "physical")
+            break
+        case "0105":    //Tap Down 4x
+            buttonEvent(4, "held", "physical")
+            break
+        case "0106":    //Tap Down 5x
+            buttonEvent(5, "held", "physical")
+            break
+        case "0102":    //Hold Down
+            buttonEvent(6, "held", "physical")
+            break
+        case "0101":    //Release Down
+            buttonEvent(7, "held", "physical")
+            break
+        case "0300":    //Tap Config 1x
+            buttonEvent(8, "pushed", "physical")
+            break
+        case "0303":    //Tap Config 2x
+            buttonEvent(9, "pushed", "physical")
+            break
+        case "0304":    //Tap Config 3x
+            buttonEvent(10, "pushed", "physical")
+            break
+        case "0305":    //Tap Config 4x
+            buttonEvent(11, "pushed", "physical")
+            break
+        case "0306":    //Tap Config 5x
+            buttonEvent(12, "pushed", "physical")
+            break
+        case "0302":    //Hold Config
+            buttonEvent(13, "pushed", "physical")
+            break
+        case "0301":    //Release Config
+            buttonEvent(14, "pushed", "physical")
+            break
+        default:       //undefined button function
+            log.warn "${device.displayName} " + fireBrick("Undefined button function Scene=${data[0]} Attributes=${data[1]}")
+            break
+    }
+}
+
+void ZigbeePrivateLEDeffectStopEvent(data) {
+    Integer ledNumber = Integer.parseInt(data[0],16)+1 //internal LED number is 0-based
+    String  ledStatus = ledNumber==17?"Stop All":ledNumber==256?"User Cleared":"Stop LED${ledNumber}"
+    if (infoEnable) log.info "${device.displayName} ledEffectStopEvent=${ledStatus}"
+	switch(ledNumber){
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+        case 17:  //Full LED bar effects
+        case 256: //user double-pressed the config button to clear the notification
+			sendEvent(name:"ledEffect", value: "${ledStatus}")
+            break
+        default:  
+			log.warn "${device.displayName} " + fireBrick("Undefined LEDeffectStopEvent=${data[0]}")
+            break
+    }
+}
+
+void buttonEvent(button, action, type = "digital") {
+    if (infoEnable) log.info "${device.displayName} ${type} Button ${button} was ${action}"
+    sendEvent(name: action, value: button, isStateChange: true, type: type)
+    switch (button) {
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+            sendEvent(name:"lastButton", value: "${action=='pushed'?'Tap '.padRight(button+4, '▲'):'Tap '.padRight(button+4, '▼')}")
+            break
+        case 6:
+            sendEvent(name:"lastButton", value: "${action=='pushed'?'Hold ▲':'Hold ▼'}")
+            break
+        case 7:
+            sendEvent(name:"lastButton", value: "${action=='pushed'?'Release ▲':'Release ▼'}")
+            break
+        case 8:
+        case 9:
+        case 10:
+        case 11:
+        case 12:
+            sendEvent(name:"lastButton", value: "Tap ".padRight(button-3, "►"))
+            break
+        case 13:
+            sendEvent(name:"lastButton", value: "Hold ►")
+            break
+        case 14:
+            sendEvent(name:"lastButton", value: "Release ►")
+            break
+    }
+}
+
+void hold(button)    {buttonEvent(button, "held", "digital")}
+void push(button)    {buttonEvent(button, "pushed", "digital")}
+void release(button) {buttonEvent(button, "released", "digital")}
+
+def pressUpX1()      {buttonEvent(1, "pushed", "digital")}
+def pressDownX1()    {buttonEvent(1, "held", "digital")}
+def pressUpX2()      {buttonEvent(2, "pushed", "digital")}
+def pressDownX2()    {buttonEvent(2, "held", "digital")}
+def pressUpX3()      {buttonEvent(3, "pushed", "digital")}
+def pressDownX3()    {buttonEvent(3, "held", "digital")}
+def pressUpX4()      {buttonEvent(4, "pushed", "digital")}
+def pressDownX4()    {buttonEvent(4, "held", "digital")}
+def pressUpX5()      {buttonEvent(5, "pushed", "digital")}
+def pressDownX5()    {buttonEvent(5, "held", "digital")}
+def holdUp()         {buttonEvent(6, "pushed", "digital")}
+def holdDown()       {buttonEvent(6, "held", "digital")}
+def releaseUp()      {buttonEvent(7, "pushed", "digital")}
+def releaseDown()    {buttonEvent(7, "held", "digital")}
+def pressConfigX1()  {buttonEvent(8, "pushed", "digital")}
+def pressConfigX2()  {buttonEvent(9, "pushed", "digital")}
+def pressConfigX3()  {buttonEvent(10, "pushed", "digital")}
+def pressConfigX4()  {buttonEvent(11, "pushed", "digital")}
+def pressConfigX5()  {buttonEvent(12, "pushed", "digital")}
+def holdConfig()     {buttonEvent(13, "held", "digital")}
+def releaseConfig()  {buttonEvent(14, "released", "digital")}
+
 @Field static Integer shortDelay = 333		//default delay to use for zigbee commands (in milliseconds)
 @Field static Integer longDelay = 1000		//long delay to use for changing modes (in milliseconds)
 @Field static Integer defaultQuickLevel=50	//default startup level for QuickStart emulation
-
 @Field static Map configParams = [
     parameter001 : [
         number: 1,
@@ -1314,1896 +3180,6 @@ def getReadOnlyParams() {
         value: null
         ]
 ]
-
-def infoLogsOff() {
-    log.warn "${device.displayName} " + fireBrick("Disabling Info logging after timeout")
-    device.updateSetting("infoEnable",[value:"false",type:"bool"])
-    //device.updateSetting("disableInfoLogging",[value:"",type:"number"])
-}
-
-def traceLogsOff() {
-    log.warn "${device.displayName} " + fireBrick("Disabling Trace logging after timeout")
-    device.updateSetting("traceEnable",[value:"false",type:"bool"])
-    //device.updateSetting("disableTraceLogging",[value:"",type:"number"])
-}
-
-def debugLogsOff() {
-    log.warn "${device.displayName} " + fireBrick("Disabling Debug logging after timeout")
-    device.updateSetting("debugEnable",[value:"false",type:"bool"])
-    //device.updateSetting("disableDebugLogging",[value:"",type:"number"])
-}
-
-def bind(cmds=[]) {
-    if (infoEnable) log.info "${device.displayName} bind(${cmds})"
-    state.lastCommandSent =						   "bind(${cmds})"
-    state.lastCommandTime = nowFormatted()
-    return cmds
-}
-
-def bindGroup(action="", group=0) {
-    if (infoEnable) log.info "${device.displayName} bindGroup($action, $group))"
-    state.lastCommandSent =                        "bindGroup($action, $group))"
-    state.lastCommandTime = nowFormatted()
-	def cmds = []
-	if (action=="bind" || action=="unbind") {
-		cmds += ["zdo $action 0x${device.deviceNetworkId} 0x02 0x01 0x0006 {${device.zigbeeId}} {${zigbee.convertToHexString(group.toInteger(),4)}}"]
-		cmds += ["zdo $action 0x${device.deviceNetworkId} 0x02 0x01 0x0008 {${device.zigbeeId}} {${zigbee.convertToHexString(group.toInteger(),4)}}"]
-		cmds += "delay 60000"		//binding can take up to 60 seconds 
-		cmds += getParameter(51)	//update number of bindings counter
-		sendHubCommand(new hubitat.device.HubMultiAction(cmds, hubitat.device.Protocol.ZIGBEE))
-	} else {
-		if (infoEnable) log.warn "${device.displayName} " + fireBrick("Invalid Bind action: '$action'")
-		}
-    if (debugEnable) log.debug "${device.displayName} bindGroup $cmds"
-    return
-}
-
-def bindInitiator() {
-    if (infoEnable) log.info "${device.displayName} bindInitiator()" 
-    state.lastCommandSent =            			   "bindInitiator()" 
-    state.lastCommandTime = nowFormatted()
-    def cmds = zigbee.command(0xfc31,0x04,["mfgCode":"0x122F"],shortDelay,"0")
-    if (debugEnable) log.debug "${device.displayName} bindInitiator $cmds"
-    return cmds
-}
-
-def bindTarget(Integer timeout=30) {
-    if (infoEnable) log.info "${device.displayName} bindTarget($timeout)"
-    state.lastCommandSent =             		   "bindTarget($timeout)"
-    state.lastCommandTime = nowFormatted()
-    def cmds = setZigbeeAttribute(3,0,timeout,16)
-    if (debugEnable) log.debug "${device.displayName} bindTarget $cmds"
-    return cmds
-}
-
-def calculateParameter(paramNum) {
-	paramNum = paramNum?:0
-    def value = Math.round((settings?."parameter${paramNum}"!=null?settings?."parameter${paramNum}":getDefaultValue(paramNum))?.toFloat())?.toInteger()
-    switch (paramNum){
-        case 9:     //Min Level
-        case 10:    //Max Level
-        case 13:    //Default Level (local)
-        case 14:    //Default Level (remote)
-        case 15:    //Level after power restored
-		case 55:	//Double-Tap UP Level
-		case 56:	//Double-Tap DOWN Level
-            value = convertPercentToByte(value)    //convert levels from percent to byte values before sending to the device
-            break
-        case 18:    //Active Power Reports (percent change)
-        case 97:    //LED Bar Intensity(when On)
-        case 98:    //LED Bar Intensity(when Off)
-			value = Math.min(Math.max(value.toInteger(),0),100)
-            break
-        case 95:    //custom hue for LED Bar (when On)
-        case 96:    //custom hue for LED Bar (when Off)
-            //360-hue values need to be converted to byte values before sending to the device
-            if (settings."parameter${paramNum}custom" =~ /^([0-9]{1}|[0-9]{2}|[0-9]{3})$/) {
-                value = Math.round((settings."parameter${paramNum}custom").toInteger()/360*255)
-            } else {   //else custom hue is invalid format or not selected
-                if(settings."parameter${paramNum}custom"!=null) {
-                    device.removeSetting("parameter${paramNum}custom")
-                    if (infoEnable||traceEnable||debugEnable) log.warn "${device.displayName} " + fireBrick("Cleared invalid custom hue: ${settings."parameter${paramNum}custom"}")
-                }
-            }
-            break
-    }
-    return value?:0
-}
-
-def calculateSize(size) {
-    if (traceEnable) log.trace "${device.displayName} calculateSize(${size})"
-	if (size==null || size==" ") size = configParams["parameter${number.toString().padLeft(3,'0')}"]?.size?:8
-    if      (size.toInteger() == 1)  return 0x10    //1-bit boolean
-    else if (size.toInteger() == 8)  return 0x20    //1-byte unsigned integer
-    else if (size.toInteger() == 16) return 0x21    //2-byte unsigned integer
-    else if (size.toInteger() == 24) return 0x22    //3-byte unsigned integer
-    else if (size.toInteger() == 32) return 0x23    //4-byte unsigned integer
-    else if (size.toInteger() == 40) return 0x24    //5-byte unsigned integer
-    else if (size.toInteger() == 48) return 0x25    //6-byte unsigned integer
-    else if (size.toInteger() == 56) return 0x26    //7-byte unsigned integer
-    else if (size.toInteger() == 64) return 0x27    //8-byte unsigned integer
-    else                             return 0x20    //default to 1-byte unsigned if no other matches
-}
-
-def clearSetting(i) {
-	i = i?:0
-	def cleared = false
-	if (settings."parameter${i}"!=null)   {cleared=true; device.removeSetting("parameter" + i)}
-	if (state."parameter${i}value"!=null) {cleared=true; state.remove("parameter" + i + "value")}
-	if (cleared && (traceEnable||debugEnable)) log.trace "${device.displayName} cleared P${i} since it is the default"
-}
-
-def clusterLookup(cluster) {
-	if (cluster==null) return "null ClusterID"
-	else {
-		//return zigbee.clusterLookup(cluster)
-		return zigbee.clusterLookup(cluster)?:cluster==0x8021?"Binding Cluster":
-										   cluster==0x8022?"UNBinding Cluster":
-										   cluster==0x8032?"Routing Table Cluster":
-										   cluster==0xFC31?"Private Cluster":
-										   "Cluster:0x${zigbee.convertToHexString(cluster,4)}"
-	}
-}
-
-def configure(option) {    //THIS GETS CALLED AUTOMATICALLY WHEN NEW DEVICE IS ADDED OR WHEN CONFIGURE BUTTON SELECTED ON DEVICE PAGE
-    option = (option==null||option==" ")?"":option
-    if (infoEnable) log.info "${device.displayName} configure($option)"
-    state.lastCommandSent =                        "configure($option)"
-    state.lastCommandTime = nowFormatted()
-    sendEvent(name: "numberOfButtons", value: 14)
-    def cmds = []
-	if (infoEnable) log.info "${device.displayName} re-establish lifeline bindings to hub"
-//  cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0000 {${device.zigbeeId}} {}", "delay ${666}"] //Basic Cluster
-//  cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0x0000 {${device.zigbeeId}} {}", "delay ${666}"] //Basic Cluster ep2
-//  cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0003 {${device.zigbeeId}} {}", "delay ${666}"] //Identify Cluster
-//  cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0x0003 {${device.zigbeeId}} {}", "delay ${666}"] //Identify Cluster ep2
-//  cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0004 {${device.zigbeeId}} {}", "delay ${666}"] //Group Cluster
-//  cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0x0004 {${device.zigbeeId}} {}", "delay ${666}"] //Group Cluster ep2
-//  cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0005 {${device.zigbeeId}} {}", "delay ${666}"] //Scenes Cluster
-//  cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0x0005 {${device.zigbeeId}} {}", "delay ${666}"] //Scenes Cluster ep2
-	cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0006 {${device.zigbeeId}} {}", "delay ${666}"] //On_Off Cluster
-//  cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0x0006 {${device.zigbeeId}} {}", "delay ${666}"] //On_Off Cluster ep2
-	cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0008 {${device.zigbeeId}} {}", "delay ${666}"] //Level Control Cluster
-//  cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0x0008 {${device.zigbeeId}} {}", "delay ${666}"] //Level Control Cluster ep2
-	cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0019 {${device.zigbeeId}} {}", "delay ${666}"] //OTA Upgrade Cluster
-	if (state.model?.substring(0,5)!="VZM35") {  //Fan does not support power/energy reports
-		cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0702 {${device.zigbeeId}} {}", "delay ${666}"] //Simple Metering - to get energy reports
-		cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x0B04 {${device.zigbeeId}} {}", "delay ${666}"] //Electrical Measurement - to get power reports
-	}
-	cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x8021 {${device.zigbeeId}} {}", "delay ${666}"] //Binding Cluster 
-	cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0x8022 {${device.zigbeeId}} {}", "delay ${666}"] //UnBinding Cluster
-	cmds += ["zdo bind ${device.deviceNetworkId} 0x01 0x01 0xFC31 {${device.zigbeeId}} {}", "delay ${666}"] //Private Cluster
-	cmds += ["zdo bind ${device.deviceNetworkId} 0x02 0x01 0xFC31 {${device.zigbeeId}} {}", "delay ${666}"] //Private Cluster ep2
-
-    if (option=="") {		//IF   we didn't pick an option 
-		cmds += refresh()	//THEN refresh read-only and key parameters
-    } else { 				//ELSE read device attributes and pass on to update settings.
-		cmds += readDeviceAttributes()
-		cmds += updated(option)
-	}
-    if (debugEnable) log.debug "${device.displayName} configure $cmds"
-    return cmds
-}
-
-def convertByteToPercent(int value=0) {                  //convert a 0-254 range where 254=100%.  255 is reserved for special meaning.
-    //if (debugEnable) log.debug "${device.displayName} convertByteToPercent(${value})"
-    value = value==null?0:value                          //default to 0 if null
-    value = Math.min(Math.max(value.toInteger(),0),255)  //make sure input byte value is in the 0-255 range
-    value = value>=255?256:value                         //this ensures that byte values of 255 get rounded up to 101%
-    value = Math.ceil(value/255*100)                     //convert to 0-100 where 254=100% and 255 becomes 101 for special meaning
-    return value
-}
-
-def convertPercentToByte(int value=0) {                  //convert a 0-100 range where 100%=254.  255 is reserved for special meaning.
-    //if (debugEnable) log.debug "${device.displayName} convertPercentToByte(${value})"
-    value = value==null?0:value                          //default to 0 if null
-    value = Math.min(Math.max(value.toInteger(),0),101)  //make sure input percent value is in the 0-101 range
-    value = Math.floor(value/100*255)                    //convert to 0-255 where 100%=254 and 101 becomes 255 for special meaning
-    value = value==255?254:value                         //this ensures that 100% rounds down to byte value 254
-    value = value>255?255:value                          //this ensures that 101% rounds down to byte value 255
-    return value
-}
-
-def cycleSpeed() {    // FOR FAN ONLY
-    def cmds =[]
-    if (parameter158=="1" || parameter258=="1") cmds += toggle()    //if we are in on/off mode then do a toggle instead of cycle
-    else {
-        def currentLevel = device.currentValue("level")==null?0:device.currentValue("level").toInteger()
-        if (device.currentValue("switch")=="off") currentLevel = 0
-		boolean smartMode = device.currentValue("smartFan")=="Enabled"
-        def newLevel = 0
-		def newSpeed =""
-		if      (currentLevel<=0 ) {newLevel=20;               newSpeed="low" }
-		else if (currentLevel<=20) {newLevel=smartMode?40:60;  newSpeed=smartMode?"medium-low":"medium"}
-		else if (currentLevel<=40) {newLevel=60;               newSpeed="medium"}
-		else if (currentLevel<=60) {newLevel=smartMode?80:100; newSpeed=smartMode?"medium-high":"high"}
-		else if (currentLevel<=80) {newLevel=100;              newSpeed="high"}
-        else                       {newLevel=0;                newSpeed="off"}
-        if (infoEnable) log.info "${device.displayName} cycleSpeed(${device.currentValue("speed")}->${newSpeed})"
-        state.lastCommandSent =                        "cycleSpeed(${device.currentValue("speed")}->${newSpeed})"
-        state.lastCommandTime = nowFormatted()
-        cmds += zigbee.setLevel(newLevel)
-        if (debugEnable) log.debug "${device.displayName} cycleSpeed $cmds"
-    }
-    return cmds
-}
-
-def getDefaultValue(paramNum=0) {
-	paramValue=configParams["parameter${paramNum.toString()?.padLeft(3,"0")}"]?.default?.toInteger()
-	return paramValue?:0
-	}
-
-def identify(seconds) {
-    if (infoEnable) log.info "${device.displayName} identify(${seconds==null?"":seconds})"
-    state.lastCommandSent =                        "identify(${seconds==null?"":seconds})"
-    state.lastCommandTime = nowFormatted()
-    def cmds = setZigbeeAttribute(3,0,seconds,16)
-    if (debugEnable) log.debug "${device.displayName} identify $cmds"
-    return cmds
-}
-
-def initialize() {    //CALLED DURING HUB BOOTUP IF "INITIALIZE" CAPABILITY IS DECLARED IN METADATA SECTION
-    log.info "${device.displayName} initialize()"
-    //save the group IDs before clearing all the state variables and reset them after
-	if (state.groupBinding1) saveBinding1 = state.groupBinding1
-	if (state.groupBinding2) saveBinding2 = state.groupBinding2
-	if (state.groupBinding3) saveBinding3 = state.groupBinding3
-    state.clear()
-	if (saveBinding1) state.groupBinding1 = saveBinding1
-	if (saveBinding2) state.groupBinding2 = saveBinding2
-	if (saveBinding3) state.groupBinding3 = saveBinding3
-    state.lastCommandSent = "initialize()"
-    state.lastCommandTime = nowFormatted()
-    state.driverDate = getDriverDate()
-	state.model = device.getDataValue('model')
-    device.removeSetting("parameter23level")
-    device.removeSetting("parameter95custom")
-    device.removeSetting("parameter96custom")
-    def cmds = []
-	cmds += ledEffectOne(1234567,255,0,0,0)	//clear any outstanding oneLED Effects
-	cmds += ledEffectAll(255,0,0,0)			//clear any outstanding allLED Effects
-    cmds += refresh()
-    if (debugEnable) log.debug "${device.displayName} initialize $cmds"
-    return cmds
-}
-
-def installed() {    //THIS IS CALLED WHEN A DEVICE IS INSTALLED
-    log.info "${device.displayName} installed()"
-    state.lastCommandSent =        "installed()"
-    state.lastCommandTime = nowFormatted()
-    state.driverDate = getDriverDate()
-	state.model = device.getDataValue('model')
-    log.info "${device.displayName} Driver Date $state.driverDate"
-    log.info "${device.displayName} Model=$state.model"
-    //configure()     //I confirmed configure() gets called at Install time so this isn't needed here
-    return
-}
-
-def intTo8bitUnsignedHex(value) {
-    return zigbee.convertToHexString(value.toInteger(),2)
-}
-
-def intTo16bitUnsignedHex(value) {
-    return zigbee.convertToHexString(value.toInteger(),4)
-}
-
-def intTo32bitUnsignedHex(value) {
-    return hexStr = zigbee.convertToHexString(value.toInteger(),8)
-}
-
-def ledEffectAll(effect=255, color=0, level=100, duration=60) {
-	effect   = effect.toString().split(/=/)[0]
-	def effectName = "unknown($effect)"
-    switch (effect){
-        case "255":	effectName = "Stop"; break
-        case "1":	effectName = "Solid"; break
-        case "2":	effectName = "Fast Blink"; break
-        case "3":	effectName = "Slow Blink"; break
-        case "4":	effectName = "Pulse"; break
-        case "5":	effectName = "Chase"; break
-        case "6":	effectName = "Open/Close"; break
-        case "7":	effectName = "Small-to-Big"; break
-        case "8":	effectName = "Aurora"; break
-        case "9":	effectName = "Slow Falling"; break
-        case "10":	effectName = "Medium Falling"; break
-        case "11":	effectName = "Fast Falling"; break
-        case "12":	effectName = "Slow Rising"; break
-        case "13":	effectName = "Medium Rising"; break
-        case "14":	effectName = "Fast Rising"; break
-        case "15":	effectName = "Medium Blink"; break
-        case "16":	effectName = "Slow Chase"; break
-        case "17":	effectName = "Fast Chase"; break
-        case "18":	effectName = "Fast Siren"; break
-        case "19":	effectName = "Slow Siren"; break
-        case "0":	effectName = "LEDs Off"; break
-		default:	effectName = "Unknown Effect #$effect"; break
-	}
-    sendEvent(name:"ledEffect", value: "$effectName All")
-    if (infoEnable) log.info "${device.displayName} ledEffectAll(${effect},${color},${level},${duration})"
-    state.lastCommandSent =                        "ledEffectAll(${effect},${color},${level},${duration})"
-    state.lastCommandTime = nowFormatted()
-    effect   = Math.min(Math.max((effect!=null?effect:255).toInteger(),0),255)
-    color    = Math.min(Math.max((color!=null?color:0).toInteger(),0),255)
-    level    = Math.min(Math.max((level!=null?level:100).toInteger(),0),100)
-    duration = Math.min(Math.max((duration!=null?duration:60).toInteger(),0),255)
-    def cmds =[]
-    Integer cmdEffect = effect.toInteger()
-    Integer cmdColor = color.toInteger()
-    Integer cmdLevel = level.toInteger()
-    Integer cmdDuration = duration.toInteger()
-    cmds += zigbee.command(0xfc31,0x01,["mfgCode":"0x122F"],shortDelay,"${intTo8bitUnsignedHex(cmdEffect)} ${intTo8bitUnsignedHex(cmdColor)} ${intTo8bitUnsignedHex(cmdLevel)} ${intTo8bitUnsignedHex(cmdDuration)}")
-    if (debugEnable) log.debug "${device.displayName} ledEffectAll $cmds"
-    return cmds
-}
-                                        
-def ledEffectOne(lednum, effect=255, color=0, level=100, duration=60) {
-	lednum   = lednum.toString().split(/ /)[0].replace(",","")
-	effect   = effect.toString().split(/=/)[0]
-	def effectName = "unknown($effect)"
-    switch (effect){
-        case "255":	effectName = "Stop"; break
-        case "1":	effectName = "Solid"; break
-        case "2":	effectName = "Fast Blink"; break
-        case "3":	effectName = "Slow Blink"; break
-        case "4":	effectName = "Pulse"; break
-        case "5":	effectName = "Chase"; break
-        case "6":	effectName = "Falling"; break
-        case "7":	effectName = "Rising"; break
-        case "8":	effectName = "Aurora"; break
-        case "0":	effectName = "LEDs Off"; break
-		default:	effectName = "Unknown Effect #$effect"; break
-	}
-	sendEvent(name:"ledEffect", value: "$effectName LED${lednum.toString().split(/ /)[0]}")
-    if (infoEnable) log.info "${device.displayName} ledEffectOne(${lednum},${effect},${color},${level},${duration})"
-    state.lastCommandSent =                        "ledEffectOne(${lednum},${effect},${color},${level},${duration})"
-    state.lastCommandTime = nowFormatted()
-    effect   = Math.min(Math.max((effect!=null?effect:255).toInteger(),0),255)
-    color    = Math.min(Math.max((color!=null?color:0).toInteger(),0),255)
-    level    = Math.min(Math.max((level!=null?level:100).toInteger(),0),100)
-    duration = Math.min(Math.max((duration!=null?duration:60).toInteger(),0),255)
-    def cmds = []
-    lednum.toString().each {
-        it= Math.min(Math.max((it!=null?it:1).toInteger(),1),7)
-        Integer cmdLedNum = (it.toInteger()-1)    //lednum is 0-based in firmware 
-        Integer cmdEffect = effect.toInteger()
-        Integer cmdColor = color.toInteger()
-        Integer cmdLevel = level.toInteger()
-        Integer cmdDuration = duration.toInteger()
-        cmds += zigbee.command(0xfc31,0x03,["mfgCode":"0x122F"],100,"${intTo8bitUnsignedHex(cmdLedNum)} ${intTo8bitUnsignedHex(cmdEffect)} ${intTo8bitUnsignedHex(cmdColor)} ${intTo8bitUnsignedHex(cmdLevel)} ${intTo8bitUnsignedHex(cmdDuration)}")
-    }
-    if (debugEnable) log.debug "${device.displayName} ledEffectOne $cmds"
-    return cmds
-}
-
-def nowFormatted() {
-    if(location.timeZone) return new Date().format("yyyy-MMM-dd h:mm:ss a", location.timeZone)
-    else                  return new Date().format("yyyy MMM dd EEE h:mm:ss a")
-}
-
-def off() {
-	if (infoEnable) log.info "${device.displayName} off()"
-    state.lastCommandSent =                        "off()"
-    state.lastCommandTime = nowFormatted()
-    def cmds = []
-    cmds += zigbee.off(shortDelay)
-    if (debugEnable) log.debug "${device.displayName} off $cmds"
-    return cmds
-}
-
-def on() {
-    if (infoEnable) log.info "${device.displayName} on()"
-    state.lastCommandSent =                        "on()"
-    state.lastCommandTime = nowFormatted()
-    def cmds = []
-    if (settings.parameter23?.toInteger()>0) cmds += quickStart() //do quickStart if enabled
-	else cmds += zigbee.on(shortDelay)						  //ELSE just turn On
-    if (debugEnable) log.debug "${device.displayName} on $cmds"
-    return cmds
-}
-def traceCluster(String description) {
-    Map descMap = zigbee.parseDescriptionAsMap(description)
-    //try {      def eventDesc=zigbee.getEvent(description)}
-	//catch (e) {def eventDesc=null}
-	def traceClusterName= clusterLookup(descMap.clusterInt?.toInteger())
-	log.trace "${device.displayName} ${darkOrange(traceClusterName)} " +
-		"(cluster:${descMap.clusterId!=null?descMap.clusterId:descMap.cluster}" +
-        (descMap.attrId==null?"":" attr:${descMap.attrId}") +
-        (descMap.value ==null?"":" value:${descMap.value}") +
-        (descMap.data  ==null?"":" data:${descMap.data}") + 
-        ")"	
-}
-
-def parse(String description) {
-    if (traceEnable) log.trace "${device.displayName} parse($description)"
-    Map descMap = zigbee.parseDescriptionAsMap(description)
-    try {
-		if (debugEnable && (zigbee.getEvent(description)!=[:])) log.debug "${device.displayName} zigbee.getEvent ${zigbee.getEvent(description)}"
-	} catch (e) {
-		if (debugEnable) log.debug "${device.displayName} "+magenta(bold("There was an error while calling zigbee.getEvent: $description"))
-	}
-	def attrId=		descMap.attrId
-    def attrInt=	descMap.attrInt
-    def clusterId=	descMap.clusterId!=null?descMap.clusterId:descMap.cluster
-    def clusterInt=	descMap.clusterInt
-	def clusterName=clusterLookup(clusterInt)
-	def valueInt	//declared empty at top level so values can be assigned in each case and then displayed at the bottom
-    //try {
-	//	def valueInt=Integer.parseInt(descMap['value'],16)
-	//} catch (e) {
-	//	def valueInt=null
-	//}
-    def valueStr =   descMap['value']?:"unknown"
-    switch (clusterInt){
-        case 0x0000:    //BASIC CLUSTER
-            if (traceEnable||debugEnable) traceCluster(description)
-            switch (attrInt) {
-                case 0x0000:
-                    if (infoEnable) log.info "${device.displayName} ZCL Version=$valueStr"
-                    state.zclVersion = valueStr
-                    break
-                case 0x0001:
-                    if (infoEnable) log.info "${device.displayName} Application Version=$valueStr"
-                    state.applicationVersion = valueStr
-                    break
-                case 0x0002:
-                    if (infoEnable) log.info "${device.displayName} Stack Version=$valueStr"
-                    state.stackVersion = valueStr
-                    break
-                case 0x0003:
-                    if (infoEnable) log.info "${device.displayName} HW Version=$valueStr"
-                    state.hwVersion = valueStr
-                    break
-                case 0x0004:
-                    if (infoEnable) log.info "${device.displayName} Mfg=$valueStr"
-                    state.manufacturer = valueStr
-					if (device.getDataValue('manufacturer')!= valueStr) device.updateDataValue('manufacturer',valueStr)
-                    break
-                case 0x0005:
-                    if (infoEnable) log.info "${device.displayName} Model=$valueStr"
-                    state.model = valueStr
-					if (device.getDataValue('model')!= valueStr) device.updateDataValue('model',valueStr)
-                    break
-                case 0x0006:
-                    if (infoEnable) log.info "${device.displayName} FW Date=$valueStr"
-					state.fwDate = valueStr
-                    break
-                case 0x0007:
-                    valueInt = Integer.parseInt(descMap['value'],16)
-                    valueStr = (valueInt==0?"Non-Neutral":(valueInt==1?"Neutral":"undefined"))
-                    if (infoEnable) log.info "${device.displayName} Power Source=$valueInt ($valueStr)"
-					sendEvent(name:"powerSource", value:valueStr)
-                    state.parameter21value = valueInt
-                    device.updateSetting("parameter21",[value:"${valueInt}",type:"enum"]) 
-                    break
-                case 0x4000:
-                    if (infoEnable) log.info "${device.displayName} FW Version=$valueStr"
-					state.fwVersion = valueStr
-                    break
-                default:
-                    log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
-                    break
-            }
-            break
-        case 0x0001:    //Power configuration
-            //if (infoEnable||debugEnable) log.info "${device.displayName} " + darkOrange("Power_Configuration Cluster:") + (debugEnable?descMap:"")
-            if (infoEnable||traceEnable||debugEnable) traceCluster(description)
-            break
-        case 0x0002:    //Device temperature configuration
-            //if (infoEnable||debugEnable) log.info "${device.displayName} " + darkOrange("Device_Temperature Cluster:") + (debugEnable?descMap:"")
-            if (infoEnable||traceEnable||debugEnable) traceCluster(description)
-            break
-        case 0x0003:    //IDENTIFY CLUSTER
-            if (traceEnable||debugEnable) traceCluster(description)
-            switch (attrInt) {
-                case 0x0000:
-                    if (infoEnable) log.info "${device.displayName} Remaining Identify Time=${zigbee.convertHexToInt(valueStr)}s"
-                    break
-                default:
-                    log.warn "${device.displayName} "+fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
-                    break
-            }
-            break
-        case 0x0004:    //GROUP CLUSTER
-            if (traceEnable||debugEnable) traceCluster(description)
-            switch (attrInt) {
-                case 0x0000:
-                    if (infoEnable) log.info "${device.displayName} Group Name Support=$valueStr"
-                    break
-                default:
-                    if (attrInt==null && descMap.messageType=="00" && descMap.direction=="01") {
-						def groupNumHex = descMap.data[2]+descMap.data[1]
-						def groupNumInt = zigbee.convertHexToInt(groupNumHex)
-						switch (descMap.command) {
-							case "00":
-								if (infoEnable) log.info "${device.displayName} Add Group $groupNumInt (0x$groupNumHex)"
-								bindGroup("bind",groupNumInt)
-								if (settings.groupBinding1==null || settings.groupBinding1?.toInteger()==groupNumInt || state.groupBinding1?.toInteger()==groupNumInt) {
-									device.updateSetting("groupBinding1",[value:groupNumInt,type:"number"])
-									state.groupBinding1=groupNumInt
-								} else if (settings.groupBinding2==null || settings.groupBinding2?.toInteger()==groupNumInt || state.groupBinding2?.toInteger()==groupNumInt) {
-									device.updateSetting("groupBinding2",[value:groupNumInt,type:"number"])
-									state.groupBinding2=groupNumInt
-								} else if (settings.groupBinding3==null || settings.groupBinding3?.toInteger()==groupNumInt || state.groupBinding3?.toInteger()==groupNumInt) {
-									device.updateSetting("groupBinding3",[value:groupNumInt,type:"number"])
-									state.groupBinding3=groupNumInt
-								}
-								break
-							case "01":
-								if (infoEnable) log.info "${device.displayName} View Group $groupNumInt (0x$groupNumHex)"
-								break
-							case "02":
-								if (infoEnable) log.info "${device.displayName} Get Group $groupNumInt (0x$groupNumHex)"
-								break
-							case "03":
-								if (infoEnable) log.info "${device.displayName} Remove Group $groupNumInt (0x$groupNumHex)"
-								bindGroup("unbind",groupNumInt)
-								if      (settings.groupBinding1?.toInteger()==groupNumInt || state.groupBinding1?.toInteger()==groupNumInt) {device.removeSetting("groupBinding1"); state.remove(groupBinding1)}
-								else if (settings.groupBinding2?.toInteger()==groupNumInt || state.groupBinding2?.toInteger()==groupNumInt) {device.removeSetting("groupBinding2"); state.remove(groupBinding2)}
-								else if (settings.groupBinding3?.toInteger()==groupNumInt || state.groupBinding3?.toInteger()==groupNumInt) {device.removeSetting("groupBinding3"); state.remove(groupBinding3)}
-								break
-							case "04":
-								if (infoEnable) log.info "${device.displayName} Remove All Groups"
-								device.removeSetting("groupBinding1"); state.remove(groupBinding1)
-								device.removeSetting("groupBinding2"); state.remove(groupBinding2)
-								device.removeSetting("groupBinding3"); state.remove(groupBinding3)
-								break
-							case "05":
-								if (infoEnable) log.info "${device.displayName} Add group if Identifying"
-								break
-							default:
-								log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-								break
-						}
-						// remove duplicate groups
-						if (settings.groupBinding3!=null && settings.groupBinding3==settings.groupBinding2) {device.removeSetting("groupBinding3"); state.remove(groupBinding3); log.info "${device.displayName} Removed duplicate Group Bind #3"}
-						if (settings.groupBinding2!=null && settings.groupBinding2==settings.groupBinding1) {device.removeSetting("groupBinding2"); state.remove(groupBinding2); log.info "${device.displayName} Removed duplicate Group Bind #2"}
-						if (settings.groupBinding1!=null && settings.groupBinding1==settings.groupBinding3) {device.removeSetting("groupBinding3"); state.remove(groupBinding3); log.info "${device.displayName} Removed duplicate Group Bind #3"}
-					} else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
-                    break
-            }
-            break
-        case 0x0005:    //SCENES CLUSTER
-            if (traceEnable||debugEnable) traceCluster(description)
-            switch (attrInt) {
-                case 0x0000:
-                    if (infoEnable) log.info "${device.displayName} Scene Count=$valueStr"
-                    break
-                case 0x0001:
-                    if (infoEnable) log.info "${device.displayName} Current Scene=$valueStr"
-                    break
-                case 0x0002:
-                    if (infoEnable) log.info "${device.displayName} Current Group=$valueStr"
-                    break
-                case 0x0003:
-                    if (infoEnable) log.info "${device.displayName} Scene Valid=$valueStr"
-                    break
-                case 0x0004:
-                    if (infoEnable) log.info "${device.displayName} Scene Name Support=$valueStr"
-                    break
-                default:
-                    log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
-                    break
-            }
-            break
-        case 0x0006:    //ON_OFF CLUSTER
-            if (traceEnable||debugEnable) traceCluster(description)
-            switch (attrInt) {
-                case 0x0000:
-                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        valueStr = (valueInt==0?"off":(valueInt==1?"on":"undefined"))
-                        if (infoEnable) log.info "${device.displayName} Switch=$valueInt ($valueStr)"
-                        sendEvent(name:"switch", value: valueStr)
-						def currentLevel = device.currentValue("level")==null?0:device.currentValue("level").toInteger()
-                        if (state.model?.substring(0,5)=="VZM35") { //FOR FAN ONLY 
-							if (device.currentValue("smartFan")=="Enabled") {
-								if      (currentLevel<=20)  newSpeed="low"
-								else if (currentLevel<=40)  newSpeed="medium-low"
-								else if (currentLevel<=60)  newSpeed="medium"
-								else if (currentLevel<=80)  newSpeed="medium-high"
-								else if (currentLevel<=100) newSpeed="high"
-							} else {
-								if      (currentLevel<=33)  newSpeed="low"
-								else if (currentLevel<=66)  newSpeed="medium"
-								else if (currentLevel<=100) newSpeed="high"
-								}
-                            if      (valueStr=="off")                        newSpeed="off"
-                            else if (parameter158=="1" || parameter258=="1") newSpeed="high"
-                            if (traceEnable||debugEnable) log.trace "${device.displayName} Speed=${newSpeed}"
-                            sendEvent(name:"speed", value: "${newSpeed}")   
-                        }
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-                    break
-                case 0x4000:
-                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        if (infoEnable) log.info "${device.displayName} Global Scene Control " + descMap
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap																									  
-                    break
-                case 0x4001:
-                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        if (infoEnable) log.info "${device.displayName} On Time=${valueInt/10}s"
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap																									  
-                    break
-                case 0x4002:
-                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        if (infoEnable) log.info "${device.displayName} Off Wait Time=${valueInt/10}s"
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap																									  
-                    break
-                case 0x4003:
-                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        valueStr = (valueInt==0?"off":(valueInt==1?"on":(valueInt==2?"toggle":(valueInt==255?"Previous":"undefined"))))
-                        if (infoEnable) log.info "${device.displayName} Power-On State=$valueInt ($valueStr)"
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap																									  
-                    break
-                default:
-                    if (descMap.profileId=="0000" && descMap.command=="00" && descMap.direction=="00") {
-                        if (traceEnable||debugEnable) log.info "${device.displayName} " + 
-							fireBrick("MATCH DESCRIPTOR REQUEST Device:${descMap.data[2]}${descMap.data[1]} Profile:${descMap.data[4]}${descMap.data[3]} Cluster:${descMap.data[7]}${descMap.data[6]}")
-                    } else if (attrInt==null && descMap.command=="0B" && descMap.direction=="01") {
-                        if (settings?.parameter51) {    //not sure why the firmware sends these when there are no bindings
-                            if (descMap.data[0]=="00" && infoEnable) log.info "${device.displayName} Bind Command Sent: Switch OFF"
-                            if (descMap.data[0]=="01" && infoEnable) log.info "${device.displayName} Bind Command Sent: Switch ON"
-                            if (descMap.data[0]=="02" && infoEnable) log.info "${device.displayName} Bind Command Sent: Toggle"
-                        }
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
-                    break
-            }
-            break
-        case 0x0008:    //LEVEL CONTROL CLUSTER
-            if (traceEnable||debugEnable) traceCluster(description)
-            switch (attrInt) {
-                case 0x0000:
-                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        valueInt=Math.min(Math.max(valueInt.toInteger(),0),254)
-                        def percentValue = convertByteToPercent(valueInt)
-                        valueStr = percentValue.toString()+"%"
-                        if (infoEnable) log.info "${device.displayName} Level=$valueInt ($valueStr)"
-                        sendEvent(name:"level", value: percentValue, unit: "%")
-		                def newSpeed =""
-                        if (state.model?.substring(0,5)=="VZM35") { //FOR FAN ONLY
-							if (device.currentValue("smartFan")=="Enabled") {
-								if      (percentValue<=20)  newSpeed="low"
-								else if (percentValue<=40)  newSpeed="medium-low"
-								else if (percentValue<=60)  newSpeed="medium"
-								else if (percentValue<=80)  newSpeed="medium-high"
-								else if (percentValue<=100) newSpeed="high"
-							} else {
-								if      (percentValue<=33)  newSpeed="low"
-								else if (percentValue<=66)  newSpeed="medium"
-								else if (percentValue<=100) newSpeed="high"
-								}
-                            if (device.currentValue("switch")=="off")        newSpeed="off"
-                            else if (parameter158=="1" || parameter258=="1") newSpeed="high"
-                            if (infoEnable) log.info "${device.displayName} Speed=${newSpeed}"
-                            sendEvent(name:"speed", value: "${newSpeed}")   
-                        }
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-					break
-                case 0x0001:
-                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-						if (infoEnable) log.info "${device.displayName} Remaining Time=${valueInt/10}s"
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-                    break
-                case 0x0002:
-                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-						if (infoEnable) log.info "${device.displayName} Min Level=${valueInt}s"
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-                    break
-                case 0x0003:
-                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-						if (infoEnable) log.info "${device.displayName} Max Level=${valueInt/10}s"
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-                    break
-				case 0x000F:
-                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        if (infoEnable) log.info "${device.displayName} Level Control Options: 0x${zigbee.convertToHexString(valueInt,2)}"
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-                    break
-                case 0x0010:
-                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        if (infoEnable) log.info "${device.displayName} On/Off Transition=${valueInt/10}s"
-                        state.parameter3value = valueInt
-                        device.updateSetting("parameter3",[value:"${valueInt}",type:configParams["parameter003"].type?.toString()])
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-                    break
-                case 0x0011:
-                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        valueStr = (valueInt==255?"Previous":convertByteToPercent(valueInt).toString()+"%")
-                        if (infoEnable) log.info "${device.displayName} Default On Level=$valueInt ($valueStr)"
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-                    break
-                case 0x0012:
-                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        if (infoEnable) log.info "${device.displayName} On Transition=${valueInt/10}s"
-                        state.parameter3value = valueInt
-                        state.parameter4value = valueInt
-                        device.updateSetting("parameter3",[value:"${valueInt}",type:configParams["parameter003"].type?.toString()])
-                        device.updateSetting("parameter4",[value:"${valueInt}",type:configParams["parameter004"].type?.toString()])
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-                    break
-                case 0x0013:
-                    if(descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        if (infoEnable) log.info "${device.displayName} Off Transition=${valueInt/10}s"
-                        state.parameter7value = valueInt
-                        state.parameter8value = valueInt
-                        device.updateSetting("parameter7",[value:"${valueInt}",type:configParams["parameter007"].type?.toString()])
-                        device.updateSetting("parameter8",[value:"${valueInt}",type:configParams["parameter008"].type?.toString()])
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-                    break
-                case 0x4000:
-                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        valueStr = (valueInt==255?"Previous":convertByteToPercent(valueInt).toString()+"%")
-                        if (infoEnable) log.info "${device.displayName} Power-On Level=$valueInt ($valueStr)"
-                        state.parameter15value = convertByteToPercent(valueInt)
-                        device.updateSetting("parameter15",[value:"${convertByteToPercent(valueInt)}",type:configParams["parameter015"].type?.toString()])
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-					break
-				default:
-                    if (attrInt==null && descMap.command=="0B" && descMap.direction=="01") {
-                        if (parameter51) {    //not sure why the firmware sends these when there are no bindings
-                            if (descMap.data[0]=="00" && infoEnable) log.info "${device.displayName} Bind Command Sent: Move To Level"
-                            if (descMap.data[0]=="01" && infoEnable) log.info "${device.displayName} Bind Command Sent: Move Up/Down"
-                            if (descMap.data[0]=="02" && infoEnable) log.info "${device.displayName} Bind Command Sent: Step"
-                            if (descMap.data[0]=="03" && infoEnable) log.info "${device.displayName} Bind Command Sent: Stop Level Change"
-                            if (descMap.data[0]=="04" && infoEnable) log.info "${device.displayName} Bind Command Sent: Move To Level (with On/Off)"
-                            if (descMap.data[0]=="05" && infoEnable) log.info "${device.displayName} Bind Command Sent: Move Up/Down (with On/Off)"
-                            if (descMap.data[0]=="06" && infoEnable) log.info "${device.displayName} Bind Command Sent: Step (with On/Off)"
-                        }
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
-					break
-			}
-			break
-        case 0x0013:    //ALEXA CLUSTER
-            if (traceEnable||debugEnable) traceCluster(description)
-            else if (infoEnable) log.info "${device.displayName} " + darkOrange("Alexa Heartbeat") //+ " $descMap"
-            break
-        case 0x0019:    //OTA CLUSTER
-            if (traceEnable||debugEnable) traceCluster(description)
-            else if (infoEnable) log.info "${device.displayName} " + darkOrange("OTA Cluster") //+ " $descMap"
-            switch (attrInt) {
-                case 0x0000:
-                    if (infoEnable) log.info "${device.displayName} Server ID=$valueStr"
-                    break
-                case 0x0001:
-                    if (infoEnable) log.info "${device.displayName} File Offset=$valueStr"
-                    break
-                case 0x0006:
-                    if (infoEnable) log.info "${device.displayName} Upgrade Status=$valueStr"
-                    break
-                default:
-                    log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
-                    break
-            }
-            break
-        case 0x0300:    //COLOR CONTROL CLUSTER
-            if (infoEnable||traceEnable||debugEnable) traceCluster(description)
-            break
-        case 0x0702:    //SIMPLE METERING CLUSTER
-            if (traceEnable||debugEnable) traceCluster(description)
-            switch (attrInt) {
-                case 0x0000:
-                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        float energy
-                        energy = valueInt/100
-                        if (infoEnable) log.info "${device.displayName} Energy=${energy}kWh"
-                        sendEvent(name:"energy",value:energy ,unit: "kWh")
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap		  													  
-                    break
-                default:
-                    log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
-                    break
-            }
-            break
-        case 0x0B04:    //ELECTRICAL MEASUREMENT CLUSTER
-            if (traceEnable||debugEnable) traceCluster(description)
-            switch (attrInt) {
-                case 0x0501:
-                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        float amps
-                        amps = valueInt/100
-                        if (infoEnable) log.info "${device.displayName} Amps=${amps}A"
-                        sendEvent(name:"amps",value:amps ,unit: "A")
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-                    break
-                case 0x050b:
-                    if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                        valueInt = Integer.parseInt(descMap['value'],16)
-                        float power 
-                        power = valueInt/10
-                        if (infoEnable) log.info "${device.displayName} Power=${power}W"
-                        sendEvent(name: "power", value: power, unit: "W")
-                    } else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap				  																																	  
-                    break
-                default:
-                    log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Attribute:$attrInt ") //+ descMap
-                    break
-            }
-            break
-        case 0x8021:    //BINDING CLUSTER
-            if (infoEnable||debugEnable) log.info  "${device.displayName} " + darkOrange("Binding Cluster ") + (debugEnable?descMap:(descMap.data==null?"":"data:${descMap.data}"))
-            if (traceEnable) traceCluster(description)
-            break
-        case 0x8022:    //UNBINDING CLUSTER
-            if (infoEnable||debugEnable) log.info "${device.displayName} "+darkOrange("UNBinding Cluster ") + (debugEnable?descMap:(descMap.data==null?"":"data:${descMap.data}"))
-            if (traceEnable) traceCluster(description)
-            break
-        case 0x8032:    //ROUTING TABLE CLUSTER
-            //if (infoEnable||debugEnable) log.info "${device.displayName} "+darkOrange("Routing_Table Cluster ") + (debugEnable?descMap:"")
-            if (infoEnable||traceEnable||debugEnable) traceCluster(description)
-            break
-        case 0xfc31:    //PRIVATE CLUSTER
-            if (traceEnable||debugEnable) traceCluster(description)
-            if (attrInt == null) {
-                if (descMap.isClusterSpecific) {
-                    if (descMap.command == "00") ZigbeePrivateCommandEvent(descMap.data)        //Button Events
-                    if (descMap.command == "04") bindInitiator()                                //Start Binding
-                    if (descMap.command == "24") ZigbeePrivateLEDeffectStopEvent(descMap.data)  //LED start/stop events
-                }
-            } else if (descMap.command == "01" || descMap.command == "0A" || descMap.command == "0B"){
-                valueInt = Integer.parseInt(descMap['value'],16)
-				def valueHex = intTo32bitUnsignedHex(valueInt)
-				def infoDev = "${device.displayName} "
-				def infoTxt = "Report: P${attrInt}=${valueInt}"
-				def infoMsg = infoDev + infoTxt
-                switch (attrInt){
-                    case 0:
-                        infoMsg += " (temporarily stored level during transitions)"
-                        break
-                    case 1:
-                        infoMsg += " (Remote Dim Rate Up: " + (valueInt<127?((valueInt/10).toString()+"s)"):"default)")
-                        break
-                    case 2:
-                        infoMsg += " (Local Dim Rate Up: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 1)")
-                        break
-                    case 3:
-                        infoMsg += " (Remote Ramp Rate On: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 1)")
-                        break
-                    case 4:
-                        infoMsg += " (Local Ramp Rate On: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 3)")
-                        break
-                    case 5:
-                        infoMsg += " (Remote Dim Rate Down: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 1)")
-                        break
-                    case 6:
-                        infoMsg += " (Local Dim Rate Down: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 2)")
-                        break
-                    case 7:
-                        infoMsg += " (Remote Ramp Rate Off: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 3)")
-                        break
-                    case 8:
-                        infoMsg += " (Local  Ramp Rate Off: " + (valueInt<127?((valueInt/10).toString()+"s)"):"sync with 4)")
-                        break
-                    case 9:     //Min Level
-                        infoMsg += " (min level ${convertByteToPercent(valueInt)}%)"
-                        break
-                    case 10:    //Max Level
-                        infoMsg += " (max level ${convertByteToPercent(valueInt)}%)" 
-                        break
-                    case 11:    //Invert Switch
-                        infoMsg += valueInt==0?" (not Inverted)":" (Inverted)" 
-                        break
-                    case 12:    //Auto Off Timer
-                        infoMsg += " (Auto Off Timer " + (valueInt==0?red("disabled"):"${valueInt}s") + ")"
-                        break
-                    case 13:    //Default Level (local)
-                        infoMsg += " (default local level " + (valueInt==255?" = previous)":" ${convertByteToPercent(valueInt)}%)")
-						sendEvent(name:"levelPreset", value:convertByteToPercent(valueInt))
-                        break
-                    case 14:    //Default Level (remote)
-                        infoMsg += " (default remote level " + (valueInt==255?" = previous)":"${convertByteToPercent(valueInt)}%)")
-                        break
-                    case 15:    //Level After Power Restored
-                        infoMsg += " (power-on level " + (valueInt==255?" = previous)":"${convertByteToPercent(valueInt)}%)")
-                        break
-                    case 17:    //Load Level Timeout
-                        infoMsg += (valueInt==0?" (do not display load level)":(valueInt==11?" (always display load level)":"s load level timeout"))
-                        break
-                    case 18: 
-                        infoMsg += " (Active Power Report" + (valueInt==0?red(" disabled"):" ${valueInt}% change") + ")"
-                        break
-                    case 19:
-                        infoMsg += "s (Periodic Power/Energy " + (valueInt==0?red(" disabled"):"") + ")"
-                        break
-                    case 20:
-                        infoMsg += " (Active Energy Report " + (valueInt==0?red(" disabled"):" ${valueInt/100}kWh change") + ")"
-                        break
-                    case 21:    //Power Source
-                        infoMsg += (valueInt==0?red(" (Non-Neutral)"):limeGreen(" (Neutral)"))
-						sendEvent(name:"powerSource", value:valueInt==0?"Non-Neutral":"Neutral")
-                        break
-                    case 22:    //Aux Type
-                        switch (state.model?.substring(0,5)){
-							case "VZM31":    //Blue 2-in-1 Dimmer
-                            case "VZW31":    //Red  2-in-1 Dimmer
-                                infoMsg += " " + (valueInt==0?"(No Aux)":(valueInt==1?"(Dumb 3-way)":(valueInt==2?"(Smart Aux)":(valueInt==3?"(No Aux Full Wave)":"(unknown type)"))))
-								state.auxType =  (valueInt==0? "No Aux": (valueInt==1? "Dumb 3-way": (valueInt==2? "Smart Aux": (valueInt==3? "No Aux Full Wave":  "unknown type $valueInt"))))
-                                break
-                            case "VZM35":    //Fan Switch
-                                infoMsg += " " + (valueInt==0?"(No Aux)":"(Smart Aux)")
-                                state.auxType =   valueInt==0? "No Aux":  "Smart Aux"
-                                break
-                            default:
-                                infoMsg = infoDev + indianRed(infoTxt + " unknown model $state.model")
-                                state.auxType = "unknown model ${state.model}"
-                                break
-                        }
-                        break
-                    case 23:    //Quick Start (in firmware on Fan, emulated in this driver for dimmer)
-                        if  (state.model?.substring(0,5)!="VZM35") 
-                            infoMsg += " (Quick Start " + (valueInt==0?red("disabled"):"${valueInt}%") + ")"
-                        else 
-                            infoMsg += " (Quick Start " + (valueInt==0?red("disabled"):"${valueInt} seconds") + ")"
-                        break
-                    case 25:    //Higher Output in non-Neutral
-                        infoMsg += " (non-Neutral High Output " + (valueInt==0?red("disabled"):limeGreen("enabled")) + ")"
-                        break
-					case 30:	//non-Neutral AUX med gear learn value
-						infoMsg += " (non-Neutral AUX medium gear)"
-						break
-					case 31:	//non-Neutral AUX low gear learn value
-						infoMsg += " (non-Neutral AUX low gear)"
-						break
-                    case 32:    //Internal Temperature (read only)
-						valueStr = "${Math.round(valueInt*9/5+32)}°F"
-                        infoMsg += " (Internal Temp: " + hue(100-valueInt.toInteger(),"${valueStr}") + ")"
-                        sendEvent(name:"internalTemp", value:valueStr)
-                        break
-                    case 33:    //Overheat (read only)
-                        infoMsg += " (Overheat: " + (valueInt==0?limeGreen("False"):valueInt==1?red("TRUE"):"undefined") + ")"
-                        sendEvent(name:"overHeat",value:valueInt==0?"False":valueInt==1?"TRUE":"undefined")
-                        break
-                    case 50:    //Button Press Delay
-                        infoMsg += " (${valueInt*100}ms Button Delay)"
-						break
-                    case 51:    //Device Bind Number
-                        infoMsg += " (Bindings)"
-                        sendEvent(name:"numberOfBindings", value:valueInt)
-                        break
-                    case 52:    //Smart Bulb/Fan Mode
-                        if (state.model?.substring(0,5)=="VZM35") {
-                            infoMsg += " (SFM " + (valueInt==0?red("disabled)"):limeGreen("enabled)"))
-                            sendEvent(name:"smartFan", value:valueInt==0?"Disabled":"Enabled")
-						} else {
-                            infoMsg += " (SBM " + (valueInt==0?red("disabled)"):limeGreen("enabled)")) + ")"
-                            sendEvent(name:"smartBulb", value:valueInt==0?"Disabled":"Enabled")
-						}
-                        break
-                    case 53:  //Double-Tap UP
-                        infoMsg += " (Double-Tap Up " + (valueInt==0?red("disabled"):limeGreen("enabled")) + ")"
-                        break
-                    case 54:  //Double-Tap DOWN
-                        infoMsg += " (Double-Tap Down " + (valueInt==0?red("disabled"):limeGreen("enabled")) + ")"
-                        break
-                    case 55:  //Double-Tap UP level
-                        infoMsg += " (Double-Tap Up level ${convertByteToPercent(valueInt)}%)"
-                        break
-                    case 56:  //Double-Tap DOWN level
-                        infoMsg += " (Double-Tap Down level ${convertByteToPercent(valueInt)}%)"
-                        break
-					case 58:  //Exclusion Behavior
-                        infoMsg += " (Exclusion: " + (valueInt==0?"LED Bar does not pulse":valueInt==1?"LED Bar pulses blue":valueInt==2?"do not Exclude":"unknown") + ")"
-						break
-					case 59:  //Association Behavior
-                        infoMsg += " (Association: " + (valueInt==0?"None":valueInt==1?"Local":valueInt==2?"Hub":"Local+Hub") + ")"
-						break
-					case 60:
-					case 65:
-					case 70:
-					case 75:
-					case 80:
-					case 85:
-					case 90:
-					case 95:	//LED(x) color when On
-						if (valueInt<255 || attrInt==95)
-							infoMsg += " " + hue(valueInt,"(LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} color when On: ${Math.round(valueInt/255*360)}°)")
-						else
-							infoMsg +=                   " (LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} color " + hue(settings.parameter95?.toInteger(),"sync with P95") + " when On)"
-						break
-					case 61:
-					case 66:
-					case 71:
-					case 76:
-					case 81:
-					case 86:
-					case 91:
-					case 96:	//LED(x) color when Off
-						if (valueInt<255 || attrInt==96)
-							infoMsg += " " + hue(valueInt,"(LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} color when Off: ${Math.round(valueInt/255*360)}°)")
-						else
-							infoMsg +=                   " (LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} color " + hue(settings.parameter96?.toInteger(),"sync with P96") + " when Off)"
-						break
-					case 62:
-					case 67:
-					case 72:
-					case 77:
-					case 82:
-					case 87:
-					case 92:
-					case 97:	//LED(x) intensity when On
-						if (valueInt<101 || attrInt==97)
-							infoMsg += "% (LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} intensity when On)"
-						else
-							infoMsg +=  " (LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} intensity sync with P97 when On)"
-						break
-					case 63:
-					case 68:
-					case 73:
-					case 78:
-					case 83:
-					case 88:
-					case 93:
-					case 98:	//LED(x) intensity when Off
-						if (valueInt<101 || attrInt==98)
-							infoMsg += "% (LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} intensity when Off)"
-						else
-							infoMsg +=  " (LED${attrInt/5-11<8?(attrInt/5-11).toInteger():" bar"} intensity sync with P98 when Off)"
-						break
-                    case 64:
-					case 69:
-					case 74:
-					case 79:
-					case 84:
-					case 89:
-					case 94:
-					case 99:	//LED(x) Notification [zwave]
-						def effectHex = valueHex.substring(0,2)
-						int effectInt = Integer.parseInt(effectHex,16)
-						infoMsg += " [0x${valueHex}] " + (effectInt==255?"(Stop Effect)":"(Start Effect ${effectInt})")
-						break
-					case 100:	//LED Bar Scaling
-                        infoMsg += " (LED Scaling " + (valueInt==0?blue("VZM-style"):red("LZW-style")) + ")"
-						break
-					case 123:	//Aux Switch Scenes
-                        infoMsg += " (Aux Scenes " + (valueInt==0?red("disabled"):limeGreen("enabled")) + ")"
-						break
-					case 125:	//Binding Off-to-On Sync Level
-                        infoMsg += " (Send Level with Binding " + (valueInt==0?red("disabled"):limeGreen("enabled")) + ")"
-						break
-                    case 156:    //Local Protection
-					case 256:
-                        infoMsg += " (Local Control " + (valueInt==0?limeGreen("enabled"):red("disabled")) + ")"
-                        break
-                    case 157:    //Remote Protection
-					case 257:
-                        infoMsg += " (Remote Control " + (valueInt==0?limeGreen("enabled"):red("disabled")) + ")"
-                        break
-                    case 158:    //Switch Mode
-					case 258:
-                        switch (state.model?.substring(0,5)){
-                            case "VZM31":    //Blue 2-in-1 Dimmer
-                            case "VZW31":    //Red  2-in-1 Dimmer
-                                infoMsg += " " + (valueInt==0?"(Dimmer mode)":"(On/Off mode)")
-                                sendEvent(name:"switchMode", value:valueInt==0?"Dimmer":"On/Off")
-                                break
-                            case "VZM35":    //Fan Switch
-								infoMsg += " " + (valueInt==0?"(Multi-Speed mode)":"(On/Off mode)")
-								sendEvent(name:"switchMode", value:valueInt==0?"Multi-Speed":"On/Off")
-								break
-                            default:
-                                infoMsg += " " + red(" unknown model $state.model")
-                                sendEvent(name:"switchMode", value:"unknown model")
-                                break
-                        }
-						break
-                    case 159:    //On-Off LED
-					case 259:
-                        infoMsg += " (On-Off LED mode: " + (valueInt==0?"All)":"One)")
-                        break
-					case 160:    //Firmware Update Indicator
-                    case 260:
-                        infoMsg += " (Firmware Update Indicator " + (valueInt==0?red("disabled"):limeGreen("enabled")) + ")"
-                        break
-					case 161:    //Relay Click
-                    case 261:
-                        infoMsg += " (Relay Click " + (valueInt==0?limeGreen("enabled"):red("disabled")) + ")"
-                        break
-					case 162:    //Double-Tap config button to clear notification
-                    case 262:
-                        infoMsg += " (Double-Tap config button " + (valueInt==0?limeGreen("enabled"):red("disabled")) + ")"
-                        break
-					case 163:    //LED bar display levels
-                    case 263:
-                        infoMsg += " (LED bar display levels: ${valueInt?:'full range'})"
-                        break
-                    default:
-						infoMsg += " [0x${valueInt<=0xFF?valueHex.substring(6):valueInt<=0xFFFF?valueHex.substring(4):valueHex}] " + orangeRed(bold("Undefined Parameter $attrInt"))
-                        break
-				}
-                if (infoEnable) log.info infoMsg //+ (traceEnable?" P:$attrInt V:$valueInt D:${getDefaultValue(attrInt)}":"")
-                if ((attrInt==9)
-				|| (attrInt==10)
-				|| (attrInt==13)
-				|| (attrInt==14)
-				|| (attrInt==15)
-				|| (attrInt==55)
-				|| (attrInt==56)) {
-					valueInt = convertByteToPercent(valueInt) //these attributes are stored as bytes but displayed as percentages
-				}
-                if ((attrInt==95 && parameter95custom!=null)||(attrInt==96 && parameter96custom!=null)) {   //if custom hue was set, update the custom user setting also
-                    device.updateSetting("parameter${attrInt}custom",[value:"${Math.round(valueInt/255*360)}",type:configParams["parameter${attrInt.toString().padLeft(3,"0")}"].type?.toString()])
-                    state."parameter${attrInt}custom" = Math.round(valueInt/255*360)
-                }
-				if (state.model?.substring(0,5)!="VZM35" && (attrInt==21 || attrInt==22 || attrInt==158 || attrInt==258)) {  //fan does not support leading/trailing edge dimming
-					state.dimmingMethod = "Leading Edge"							//default to Leading Edge
-					if (parameter21=="1") {											//if neutral wiring then select based on remote switch type
-						if (parameter22=="0") state.dimmingMethod = "Trailing Edge"	//no aux
-						if (parameter22=="1") state.dimmingMethod = "Leading Edge"	//dumb 3-way
-						if (parameter22=="2") state.dimmingMethod = "Trailing Edge"	//smart aux
-						if (parameter22=="3") {
-							if (parameter158=="1" || parameter258=="1") {			//Switch Mode is On-Off
-								state.dimmingMethod = "Full Wave"
-							} else {												//Switch Mode is Dimmer
-								state.dimmingMethod = "Trailing Edge"
-								device.updateSetting("parameter22",[value:"0",type:"enum"])
-								state.parameter22value=0
-							}
-						}
-					}
-					if (infoEnable||traceEnable||debugEnable) log.trace "${device.displayName} Dimming Method = ${state.dimmingMethod}"
-				}
-				//Update UI setting with value received from device
-				if ((valueInt==getDefaultValue(attrInt))	//IF   value is the default
-				&& (!getReadOnlyParams().contains(attrInt))	//AND  not a read-only param
-				&& (![22,52,158,258].contains(attrInt))) {	//AND  not a key parameter
-					clearSetting(attrInt)					//THEN clear the setting (so only changed settings are displayed)
-				} else {									//ELSE update local setting
-					device.updateSetting("parameter${attrInt}",[value:"${valueInt}",type:configParams["parameter${attrInt.toString().padLeft(3,"0")}"]?.type?.toString()])
-				}
-				if (settings."parameter${attrInt}"!=null) {											//IF   device setting is not null
-					state."parameter${attrInt}value" = settings."parameter${attrInt}"?.toInteger()	//THEN set state variable to device setting
-				}
-			}
-			else log.warn "${device.displayName} " + fireBrick("${clusterName} Unknown Command:$descMap.command ") //+ descMap
-            break
-        default:
-            log.warn "${device.displayName} " + fireBrick("Unknown Cluster($clusterName)  ") + description
-			break
-	}
-    state.lastEventCluster =   clusterName
-    state.lastEventTime =      nowFormatted()
-    state.lastEventAttribute = attrInt
-    state.lastEventValue =     descMap.value
-    return
-}
-
-def presetLevel(value) {
-    if (infoEnable) log.info "${device.displayName} presetLevel(${value})"
-    state.lastCommandSent =                        "presetLevel(${value})"
-    state.lastCommandTime = nowFormatted()
-    def cmds = []
-    Integer scaledValue = value==null?null:Math.min(Math.max(convertPercentToByte(value.toInteger()),1),255)  //ZigBee levels range from 0x01-0xfe with 00 and ff = 'use previous'
-    cmds += setParameter(13, scaledValue)
-    cmds += setParameter(14, scaledValue)
-    if (debugEnable) log.debug "${device.displayName} preset $cmds"
-    return cmds
-}
-
-def quickStart() {
-    quickStartVariables()
-	def startLevel = device.currentValue("level").toInteger()
-	def cmds= []
-	if (settings.parameter23?.toInteger()>0 ) {          //only do quickStart if enabled
-		if (infoEnable) log.info "${device.displayName} quickStart(" + (state.model?.substring(0,5)!="VZM35"?"${settings.parameter23}%)":"${settings.parameter23}s)")
-		if (state.model?.substring(0,5)!="VZM35") {      //IF not the Fan switch THEN emulate quickStart 
-			if (startLevel<state.parameter23value) cmds += zigbee.setLevel(state.parameter23value?.toInteger(),0,34)  //only do quickStart if currentLevel is < Quick Start Level (34ms is two sinewave cycles)
-			cmds += zigbee.setLevel(startLevel,0,longDelay) 
-			if (debugEnable) log.debug "${device.displayName} quickStart $cmds"
-		}
-	}
-    return cmds
-}
-
-def quickStartVariables() {
-    if (state.model?.substring(0,5)!="VZM35") {  //IF not the Fan switch THEN set the quickStart variables manually
-        settings.parameter23 =  (settings.parameter23!=null?settings.parameter23:getDefaultValue(23))
-        state.parameter23value = Math.round((settings.parameter23?:0).toFloat())
-        //state.parameter23level = Math.round((settings.parameter23level?:defaultQuickLevel).toFloat())
-    }
-}
-
-def readDeviceAttributes() {
-	if (traceEnable||debugEnable) log.trace "${device.displayName} readDeviceAttributes()"
-	def cmds = []
-//	cmds += zigbee.readAttribute(0x0000, 0x0000, [:], shortDelay)    //BASIC ZCL Version
-//	cmds += zigbee.readAttribute(0x0000, 0x0001, [:], shortDelay)    //BASIC Application Version
-//	cmds += zigbee.readAttribute(0x0000, 0x0002, [:], shortDelay)    //BASIC Stack Version
-//	cmds += zigbee.readAttribute(0x0000, 0x0003, [:], shortDelay)    //BASIC HW Version
-//	cmds += zigbee.readAttribute(0x0000, 0x0004, [:], shortDelay)    //BASIC Manufacturer Name
-	cmds += zigbee.readAttribute(0x0000, 0x0005, [:], shortDelay)    //BASIC Model
-	cmds += zigbee.readAttribute(0x0000, 0x0006, [:], shortDelay)    //BASIC SW Date Code
-//	cmds += zigbee.readAttribute(0x0000, 0x0007, [:], shortDelay)    //BASIC Power Source
-//	cmds += zigbee.readAttribute(0x0000, 0x0008, [:], shortDelay)    //BASIC GenericDevice-Class
-//	cmds += zigbee.readAttribute(0x0000, 0x0009, [:], shortDelay)    //BASIC GenericDevice-Type
-//	cmds += zigbee.readAttribute(0x0000, 0x000A, [:], shortDelay)    //BASIC ProductCode
-//	cmds += zigbee.readAttribute(0x0000, 0x000B, [:], shortDelay)    //BASIC ProductURL
-//	cmds += zigbee.readAttribute(0x0000, 0x000C, [:], shortDelay)    //BASIC ManufacturerVersionDetails
-//	cmds += zigbee.readAttribute(0x0000, 0x000D, [:], shortDelay)    //BASIC SerialNumber
-//	cmds += zigbee.readAttribute(0x0000, 0x000E, [:], shortDelay)    //BASIC ProductLabel
-//	cmds += zigbee.readAttribute(0x0000, 0x0010, [:], shortDelay)    //BASIC LocationDescription
-//	cmds += zigbee.readAttribute(0x0000, 0x0011, [:], shortDelay)    //BASIC PhysicalEnvironment
-//	cmds += zigbee.readAttribute(0x0000, 0x0012, [:], shortDelay)    //BASIC DeviceEnabled
-//	cmds += zigbee.readAttribute(0x0000, 0x0013, [:], shortDelay)    //BASIC AlarmMask
-//	cmds += zigbee.readAttribute(0x0000, 0x0014, [:], shortDelay)    //BASIC DisableLocalConfig
-	cmds += zigbee.readAttribute(0x0000, 0x4000, [:], shortDelay)    //BASIC SWBuildID
-//	cmds += zigbee.readAttribute(0x0003, 0x0000, [:], shortDelay)    //IDENTIFY Identify Time
-//	cmds += zigbee.readAttribute(0x0004, 0x0000, [:], shortDelay)    //GROUP Name Support
-//	cmds += zigbee.readAttribute(0x0005, 0x0000, [:], shortDelay)    //SCENES Scene Count
-//	cmds += zigbee.readAttribute(0x0005, 0x0001, [:], shortDelay)    //SCENES Current Scene
-//	cmds += zigbee.readAttribute(0x0005, 0x0002, [:], shortDelay)    //SCENES Current Group
-//	cmds += zigbee.readAttribute(0x0005, 0x0003, [:], shortDelay)    //SCENES Scene Valid
-//	cmds += zigbee.readAttribute(0x0005, 0x0004, [:], shortDelay)    //SCENES Name Support
-//	cmds += zigbee.readAttribute(0x0005, 0x0005, [:], shortDelay)    //SCENES LastConfiguredBy
-	cmds += zigbee.readAttribute(0x0006, 0x0000, [:], shortDelay)    //ON_OFF Current OnOff state
-//	cmds += zigbee.readAttribute(0x0006, 0x4000, [:], shortDelay)    //ON_OFF GlobalSceneControl
-//	cmds += zigbee.readAttribute(0x0006, 0x4001, [:], shortDelay)    //ON_OFF OnTime
-//	cmds += zigbee.readAttribute(0x0006, 0x4002, [:], shortDelay)    //ON_OFF OffWaitTime
-	cmds += zigbee.readAttribute(0x0006, 0x4003, [:], shortDelay)    //ON_OFF Startup OnOff state
-	cmds += zigbee.readAttribute(0x0008, 0x0000, [:], shortDelay)    //LEVEL_CONTROL CurrentLevel
-//	cmds += zigbee.readAttribute(0x0008, 0x0001, [:], shortDelay)    //LEVEL_CONTROL RemainingTime
-//	cmds += zigbee.readAttribute(0x0008, 0x0002, [:], shortDelay)    //LEVEL_CONTROL MinLevel
-//	cmds += zigbee.readAttribute(0x0008, 0x0003, [:], shortDelay)    //LEVEL_CONTROL MaxLevel
-//	cmds += zigbee.readAttribute(0x0008, 0x0004, [:], shortDelay)    //LEVEL_CONTROL CurrentFrequency
-//	cmds += zigbee.readAttribute(0x0008, 0x0005, [:], shortDelay)    //LEVEL_CONTROL MinFrequency
-//	cmds += zigbee.readAttribute(0x0008, 0x0006, [:], shortDelay)    //LEVEL_CONTROL MaxFrequency
-//	cmds += zigbee.readAttribute(0x0008, 0x000F, [:], shortDelay)    //LEVEL_CONTROL Options
-//	cmds += zigbee.readAttribute(0x0008, 0x0010, [:], shortDelay)    //LEVEL_CONTROL OnOff Transition Time
-//	cmds += zigbee.readAttribute(0x0008, 0x0011, [:], shortDelay)    //LEVEL_CONTROL OnLevel
-//  cmds += zigbee.readAttribute(0x0008, 0x0012, [:], shortDelay)    //LEVEL_CONTROL OnTransitionTime
-//  cmds += zigbee.readAttribute(0x0008, 0x0013, [:], shortDelay)    //LEVEL_CONTROL OffTransitionTime
-//  cmds += zigbee.readAttribute(0x0008, 0x0014, [:], shortDelay)    //LEVEL_CONTROL DefaultMoveRate
-//  cmds += zigbee.readAttribute(0x0008, 0x4000, [:], shortDelay)    //LEVEL_CONTROL StartUpCurrentLevel
-//  cmds += zigbee.readAttribute(0x0019, 0x0000, [:], shortDelay)    //OTA Upgrade Server ID
-//  cmds += zigbee.readAttribute(0x0019, 0x0001, [:], shortDelay)    //OTA File Offset
-//  cmds += zigbee.readAttribute(0x0019, 0x0002, [:], shortDelay)    //OTA CurrentFileVersion
-//  cmds += zigbee.readAttribute(0x0019, 0x0003, [:], shortDelay)    //OTA CurrentZigBeeStackVersion
-//  cmds += zigbee.readAttribute(0x0019, 0x0004, [:], shortDelay)    //OTA DownloadedFileVersion
-//  cmds += zigbee.readAttribute(0x0019, 0x0005, [:], shortDelay)    //OTA DownloadedZigBeeStackVersion
-//  cmds += zigbee.readAttribute(0x0019, 0x0006, [:], shortDelay)    //OTA Image Upgrade Status
-//  cmds += zigbee.readAttribute(0x0019, 0x0007, [:], shortDelay)    //OTA ManufacturerID 
-//  cmds += zigbee.readAttribute(0x0019, 0x0008, [:], shortDelay)    //OTA Image TypeID 
-//  cmds += zigbee.readAttribute(0x0019, 0x0009, [:], shortDelay)    //OTA MinimumBlockPeriod
-//  cmds += zigbee.readAttribute(0x0019, 0x000A, [:], shortDelay)    //OTA Image Stamp
-//  cmds += zigbee.readAttribute(0x0019, 0x000B, [:], shortDelay)    //OTA UpgradeActivationPolicy
-//  cmds += zigbee.readAttribute(0x0019, 0x000C, [:], shortDelay)    //OTA UpgradeTimeoutPolicy 
-    if (state.model?.substring(0,5)!="VZM35")	//Fan does not support power/energy reports
-      cmds += zigbee.readAttribute(0x0702, 0x0000, [:], shortDelay)  //SIMPLE_METERING Energy Report
-//  cmds += zigbee.readAttribute(0x0702, 0x0200, [:], shortDelay)    //SIMPLE_METERING Status
-//  cmds += zigbee.readAttribute(0x0702, 0x0300, [:], shortDelay)    //SIMPLE_METERING Units
-//  cmds += zigbee.readAttribute(0x0702, 0x0301, [:], shortDelay)    //SIMPLE_METERING AC Multiplier
-//  cmds += zigbee.readAttribute(0x0702, 0x0302, [:], shortDelay)    //SIMPLE_METERING AC Divisor
-//  cmds += zigbee.readAttribute(0x0702, 0x0303, [:], shortDelay)    //SIMPLE_METERING Formatting
-//  cmds += zigbee.readAttribute(0x0702, 0x0306, [:], shortDelay)    //SIMPLE_METERING Metering Device Type
-//  cmds += zigbee.readAttribute(0x0B04, 0x0501, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Line Current
-//  cmds += zigbee.readAttribute(0x0B04, 0x0502, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Active Current
-//  cmds += zigbee.readAttribute(0x0B04, 0x0503, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Reactive Current
-//  cmds += zigbee.readAttribute(0x0B04, 0x0505, [:], shortDelay)    //ELECTRICAL_MEASUREMENT RMS Voltage
-//  cmds += zigbee.readAttribute(0x0B04, 0x0506, [:], shortDelay)    //ELECTRICAL_MEASUREMENT RMS Voltage min
-//  cmds += zigbee.readAttribute(0x0B04, 0x0507, [:], shortDelay)    //ELECTRICAL_MEASUREMENT RMS Voltage max
-//  cmds += zigbee.readAttribute(0x0B04, 0x0508, [:], shortDelay)    //ELECTRICAL_MEASUREMENT RMS Current
-//  cmds += zigbee.readAttribute(0x0B04, 0x0509, [:], shortDelay)    //ELECTRICAL_MEASUREMENT RMS Current min
-//  cmds += zigbee.readAttribute(0x0B04, 0x050A, [:], shortDelay)    //ELECTRICAL_MEASUREMENT RMS Current max
-    if (state.model?.substring(0,5)!="VZM35")  //Fan does not support power/energy reports
-      cmds += zigbee.readAttribute(0x0B04, 0x050B, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Active Power
-//  cmds += zigbee.readAttribute(0x0B04, 0x050C, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Active Power min
-//  cmds += zigbee.readAttribute(0x0B04, 0x050D, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Active Power max
-//  cmds += zigbee.readAttribute(0x0B04, 0x050E, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Reactive Power
-//  cmds += zigbee.readAttribute(0x0B04, 0x050F, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Apparent Power
-//  cmds += zigbee.readAttribute(0x0B04, 0x0510, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Power Factor
-//  cmds += zigbee.readAttribute(0x0B04, 0x0604, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Power Multiplier
-//  cmds += zigbee.readAttribute(0x0B04, 0x0605, [:], shortDelay)    //ELECTRICAL_MEASUREMENT Power Divisor
-//  cmds += zigbee.readAttribute(0x8021, 0x0000, [:], shortDelay)    //Binding
-//  cmds += zigbee.readAttribute(0x8022, 0x0000, [:], shortDelay)    //UnBinding
-	return cmds
-}
-
-def refresh(option) {
-    option = (option==null||option==" ")?"":option
-    if (infoEnable) log.info "${device.displayName} refresh(${option})"
-    state.lastCommandSent =                        "refresh(${option})"
-    state.lastCommandTime = nowFormatted()
-    state.driverDate = getDriverDate()
-	state.model = device.getDataValue('model')
-    if (infoEnable||traceEnable||debugEnable) log.info "${device.displayName} Driver Date $state.driverDate"
-    def cmds = []
-	cmds += readDeviceAttributes()
-	configParams.each {	//loop through all parameters
-		int i = it.value.number.toInteger()
-		if (i==23 && (state.model?.substring(0,5)!="VZM35")) quickStartVariables()  //quickStart is implemented in firmware for the fan, emulated in this driver for 2-in-1 Dimmer
-
-		switch (option) {
-			case "":									//option is blank or null 
-				if (([22,52,158,258].contains(i))		//refresh primary settings
-				|| (getReadOnlyParams().contains(i))	//refresh read-only params
-				|| (settings."parameter${i}"!=null)) {	//refresh user settings
-					cmds += getParameter(i)
-				}
-				break
-			case "All":
-				cmds += getParameter(i) //if option is All then refresh all params
-				break
-			default: 
-				if (traceEnable||debugEnable) log.error "${device.displayName} Unknonwn option 'refresh($option)'"
-				break
-		}
-    }
-	return cmds
-}
-
-def remoteControl(option) {
-    if (infoEnable) log.info "${device.displayName} remoteControl($option)"
-    state.lastCommandSent =                        "remoteControl($option)"
-    state.lastCommandTime = nowFormatted()
-    def cmds = []
-    cmds += zigbee.command(0xfc31,0x10,["mfgCode":"0x122F"],shortDelay,"${option=="Disabled"?"01":"00"}")
-    if (debugEnable) log.debug "${device.displayName} remoteControl $cmds"
-	return cmds 
-}
-
-def resetEnergyMeter() {
-    if (infoEnable) log.info "${device.displayName} resetEnergyMeter(" + device.currentValue("energy") + "kWh)"
-    state.lastCommandSent =                        "resetEnergyMeter(" + device.currentValue("energy") + "kWh)"
-    state.lastCommandTime = nowFormatted()
-    def cmds = []
-    cmds += zigbee.command(0xfc31,0x02,["mfgCode":"0x122F"],shortDelay,"0")
-    cmds += zigbee.readAttribute(CLUSTER_SIMPLE_METERING, 0x0000)
-    if (debugEnable) log.debug "${device.displayName} resetEnergyMeter $cmds"
-    return cmds 
-}
-        
-def setAttribute(Integer cluster, Integer attrInt, Integer dataType, Integer value, Map additionalParams = [:], Integer delay=shortDelay) {
-    if (cluster==0xfc31) additionalParams = ["mfgCode":"0x122F"]
-    if (delay==null||delay==0) delay = shortDelay
-    def infoMsg = "${device.displayName} Set " + clusterLookup(cluster)
-    if (cluster==0xfc31) {
-        infoMsg += " attribute ${attrInt} dataType 0x${zigbee.convertToHexString(dataType,2)} value "
-        switch (attrInt) {
-			case 9:     //Min Level
-			case 10:    //Max Level
-			case 13:    //Default Level (local)
-			case 14:    //Default Level (remote)
-			case 15:    //Level after power restored
-			case 55:	//Double-Tap UP Level
-			case 56:	//Double-Tap DOWN Level
-                infoMsg += "${value} = ${convertByteToPercent(value)}% on 255 scale"
-                break
-            case 23:
-                quickStartVariables()
-                infoMsg = ""
-                break
-			case 60:	//LED1 color when on
-			case 61:	//LED1 color when off
-			case 65:	//LED2 color when on
-			case 66:	//LED2 color when off
-			case 70:	//LED3 color when on
-			case 71:	//LED3 color when off
-			case 75:	//LED4 color when on
-			case 76:	//LED4 color when off
-			case 80:	//LED5 color when on
-			case 81:	//LED5 color when off
-			case 85:	//LED6 color when on
-			case 86:	//LED6 color when off
-			case 90:	//LED7 color when on
-			case 91:	//LED7 color when off
-            case 95:	//LED bar color when on
-            case 96:	//LED bar color when off
-                infoMsg += "${value} = ${Math.round(value/255*360)}° on 360° scale"
-                break
-            default:
-                infoMsg += "${value}"
-                break 
-        }
-    } else {
-        infoMsg += " attribute 0x${zigbee.convertToHexString(attrInt,4)} value ${value}"
-    }
-    if (traceEnable) log.trace infoMsg + (delay==shortDelay?"":" [delay ${delay}]")
-    def cmds = zigbee.writeAttribute(cluster, attrInt, dataType, value, additionalParams, delay)
-    if (debugEnable) log.debug "${device.displayName} setAttribute $cmds"
-    return cmds
-}
-
-def getAttribute(Integer cluster, Integer attrInt=0, Map additionalParams = [:], Integer delay=shortDelay) {
-    if (cluster==0xfc31) additionalParams = ["mfgCode":"0x122F"]
-    if (delay==null||delay==0) delay = shortDelay
-    if (traceEnable) log.trace  "${device.displayName} Get "+clusterLookup(cluster)+" attribute ${attrInt}"+(delay==shortDelay?"":" [delay ${delay}]")
-    if (cluster==0xfc31 && attrInt==23 && state.model?.substring(0,5)!="VZM35") {  //if not Fan, get the quickStart values from state variables since dimmer does not store these
-		if (infoEnable) log.info "${device.displayName} Report: P${attrInt}=${state?.parameter23value} (QuickStart " + (state.parameter23value?.toInteger()==0?red("disabled"):"${state.parameter23value?.toInteger()}" + state.model?.substring(0,5)!="VZM35"?"${settings.parameter23}%":"${settings.parameter23}s") + ")"
-		if (infoEnable) log.info "${device.displayName} Report: P${attrInt} level=${state?.parameter23level} (QuickStart startup level)"
-		if (settings.parameter23level?.toInteger()==defaultQuickLevel) device.removeSetting("parameter23level") 
-    }
-	def cmds = []
-    cmds += zigbee.readAttribute(cluster, attrInt, additionalParams, delay)
-	if (debugEnable) log.debug "${device.displayName} getAttribute $cmds"
-    return cmds
-}
-
-def setLevel(value, duration=0xFFFF) {
-	if (duration==null) duration=0xFFFF
-    if (infoEnable) log.info "${device.displayName} setLevel($value" + (duration==0xFFFF?")":", ${duration}s)")
-    state.lastCommandSent =                        "setLevel($value" + (duration==0xFFFF?")":", ${duration}s)")
-    state.lastCommandTime = nowFormatted()
-    if (duration!=0xFFFF) duration = duration.toInteger()*10  //firmware duration in 10ths
-    def cmds = []
-    cmds += zigbee.setLevel(value.toInteger(),duration,shortDelay)
-    if (debugEnable) log.debug "${device.displayName} setLevel $cmds"
-	return cmds
-}
-
-def setParameter(paramNum=0, value=null, size=null, delay=shortDelay) {
-	paramNum = paramNum?.toInteger()
-	value    = value?.toInteger()
-	size     = size?.toInteger()
-	if (size==null || size==" ") size = configParams["parameter${paramNum.toString().padLeft(3,'0')}"]?.size?:8
-	if (traceEnable) log.trace "${device.displayName} setParameter($paramNum, $value, $size)"
-	state.lastCommandSent =                          "setParameter($paramNum, $value, $size)"
-	state.lastCommandTime = nowFormatted()
-	def cmds = []
-    size = calculateSize(size).toInteger()
-    if (value!=null) cmds += setAttribute(0xfc31,paramNum,size,value)	//no value means we only want to GET the value
-	if (paramNum==52 || paramNum==158 || paramNum==258) cmds += "delay $longDelay"	//allow extra time when changing modes
-    cmds += getAttribute(0xfc31, paramNum, [:], delay)
-    if (debugEnable) log.debug value!=null?"${device.displayName} setParameter $cmds":"${device.displayName} getParameter $cmds"
-    return cmds
-}
-
-def getParameter(paramNum=0, delay=shortDelay) {
-	paramNum = paramNum?.toInteger()
-    if (traceEnable) log.trace "${device.displayName} getParameter($paramNum,$delay)"
-    //state.lastCommandSent =                        "getParameter($paramNum,$delay)"
-    //state.lastCommandTime = nowFormatted() //this is not a custom command.  Only use state variable for commands on the device details page
-    def cmds = []
-	if (paramNum<0) {	//special case, if negative then read all params from 0-max (for debugging)
-		for(int i = 0;i<=(getParameterNumbers()+getReadOnlyParams()).max();i++) {
-			cmds += getAttribute(0xfc31, i, [:], 100)	//override shortDelay with very short (100ms) delay
-		}	
-	} else {	//otherwise, just get the requested parameter
-		cmds += getAttribute(0xfc31, paramNum, [:], delay)
-	}
-    if (debugEnable) log.debug "${device.displayName} getParameter $cmds"
-    return cmds
-}
-
-def setPrivateCluster(attributeId, value, size=8) {	//for backward compatibility
-	log.warn "${device.displayName} setPrivateCluster(${red(italic(bold('command is depreciated. Use setParameter instead')))})"
-    return setParameter(attributeId, value, size.toInteger())
-}
-
-def setSpeed(value) {  // FOR FAN ONLY
-    if (infoEnable) log.info "${device.displayName} setSpeed(${value})"
-    state.lastCommandSent =                        "setSpeed(${value})"
-    state.lastCommandTime = nowFormatted()
-	def currentLevel = device.currentValue("level")==null?0:device.currentValue("level").toInteger()
-	if (device.currentValue("switch")=="off") currentLevel = 0
-	boolean smartMode = device.currentValue("smartFan")=="Enabled"
-	def newLevel = 0
-    def cmds = []
-    switch (value) {
-        case "off":
-            cmds += zigbee.off(shortDelay) 
-            break
-        case "low": 
-            cmds += zigbee.setLevel(smartMode?20:33) 
-            break
-        case "medium-low":             //placeholder since Hubitat natively supports 5-speed fans
-            cmds += zigbee.setLevel(40) 
-            break
-        case "medium": 
-            cmds += zigbee.setLevel(smartMode?60:66) 
-            break
-        case "medium-high":            //placeholder since Hubitat natively supports 5-speed fans
-            cmds += zigbee.setLevel(80) 
-            break
-        case "high": 
-            cmds += zigbee.setLevel(100) 
-            break
-        case "on":
-            cmds += zigbee.on(shortDelay)
-            break
-		case "up":
-			if      (currentLevel<=0 )  {newLevel=20}
-			else if (currentLevel<=20)  {newLevel=smartMode?40:60}
-			else if (currentLevel<=40)  {newLevel=60}
-			else if (currentLevel<=60)  {newLevel=smartMode?80:100}
-			else if (currentLevel<=100) {newLevel=100}
-            cmds += zigbee.setLevel(newLevel)
-			break
-		case "down":
-			if      (currentLevel>80) {newLevel=smartMode?80:60}
-			else if (currentLevel>60) {newLevel=60}
-			else if (currentLevel>40) {newLevel=smartMode?40:20}
-			else if (currentLevel>20) {newLevel=20}
-			else if (currentLevel>0)  {newLevel=currentLevel}
-            cmds += zigbee.setLevel(newLevel)
-			break
-    }
-    if (debugEnable) log.debug "${device.displayName} setSpeed $cmds"
-    return cmds
-}
-
-def setZigbeeAttribute(cluster, attributeId, value, size) {
-    if (traceEnable) log.trace value!=null?"${device.displayName} setZigbeeAttribute(${cluster}, ${attributeId}, ${value}, ${size})":"${device.displayName} getZigbeeAttribute(${cluster}, ${attributeId})"
-    state.lastCommandSent =    value!=null?                      "setZigbeeAttribute(${cluster}, ${attributeId}, ${value}, ${size})":                      "getZigbeeAttribute(${cluster}, ${attributeId})"
-    state.lastCommandTime = nowFormatted()
-    def cmds = []
-    Integer setCluster = cluster.toInteger()
-    Integer attId = attributeId.toInteger()
-    Integer attValue = (value?:0).toInteger()
-    Integer attSize = calculateSize(size).toInteger()
-    if (value!=null) cmds += setAttribute(setCluster,attId,attSize,attValue,[:],attId==258?longDelay:shortDelay)
-    cmds += getAttribute(setCluster, attId)
-    if (debugEnable) log.debug "${device.displayName} setZigbeeAttribute $cmds"
-    return cmds
-}
-
-def startLevelChange(direction, duration=null) {
-    def newLevel = direction=="up"?100:device.currentValue("switch")=="off"?0:1
-	duration = duration!=null?duration:(calculateParameter(1)/10)
-    if (infoEnable) log.info "${device.displayName} startLevelChange(${direction}" + (duration==null?")":", ${duration}s)")
-    state.lastCommandSent =                        "startLevelChange(${direction}" + (duration==null?")":", ${duration}s)")
-    state.lastCommandTime = nowFormatted()
-	def cmds = []
-    cmds += duration==null?zigbee.setLevel(newLevel):zigbee.setLevel(newLevel, duration.toInteger()*10)
-    if (debugEnable) log.debug "${device.displayName} startLevelChange $cmds"
-	return cmds
-}
-
-def stopLevelChange() {
-    if (infoEnable) log.info "${device.displayName} stopLevelChange()" // at level " + device.currentValue("level")
-    state.lastCommandSent =                        "stopLevelChange()"
-    state.lastCommandTime = nowFormatted()
-	def cmds = []
-    cmds += ["he cmd 0x${device.deviceNetworkId} 0x${device.endpointId} ${CLUSTER_LEVEL_CONTROL} ${COMMAND_STOP} {}","delay $shortDelay"]
-    if (debugEnable) log.debug "${device.displayName} stopLevelChange $cmds"
-    return cmds
-}
-//uncomment this section if you need it for backward compatibility
-//def startNotification(value, ep = null){	//for backward compatibility
-//    def hexStr = zigbee.convertToHexString(value.toInteger(),8)	//flip bytes 2 and 4 since they are incorrect in nathan's tool
-//    def bigValue = new BigInteger(hexStr.substring(0, 2) + hexStr.substring(6, 8) + hexStr.substring(4, 6) + hexStr.substring(2, 4), 16)
-//	log.warn "${device.displayName} startNotification(${red(bold('command is depreciated. Use ledEffectAll instead'))})"
-//    if (infoEnable) log.info "${device.displayName} startNotification($bigValue [0x$hexStr])"
-//    state.lastCommandSent =                        "startNotification($bigValue [0x$hexStr])"
-//    state.lastCommandTime = nowFormatted()
-//    def cmds = []
-//    cmds += zwave.configurationV4.configurationSet(scaledConfigurationValue: bigValue, parameterNumber: ledNotificationEndpoints[(ep == null)? 0:ep?.toInteger()-1], size: 4)
-//    cmds += zwave.configurationV4.configurationGet(parameterNumber: ledNotificationEndpoints[(ep == null)? 0:ep?.toInteger()-1])
-//    if (debugEnable) log.debug "${device.displayName} startNotification $cmds"
-//    return delayBetween(cmds.collect{ secureCmd(it) }, shortDelay)
-//}
-//
-//def stopNotification(ep = null){	//for backward compatibility
-//	log.warn "${device.displayName} stopNotification(${red(bold('command is depreciated. Use ledEffectAll instead'))})"
-//    if (infoEnable) log.info "${device.displayName} stopNotification()"
-//    state.lastCommandSent =                        "stopNotification()"
-//    state.lastCommandTime = nowFormatted()
-//    def cmds = []
-//    cmds += zwave.configurationV4.configurationSet(scaledConfigurationValue: 0, parameterNumber: ledNotificationEndpoints[(ep == null)? 0:ep?.toInteger()-1], size: 4)
-//    cmds += zwave.configurationV4.configurationGet(parameterNumber: ledNotificationEndpoints[(ep == null)? 0:ep?.toInteger()-1])
-//    if (debugEnable) log.debug "${device.displayName} stopNotification $cmds"
-//    return delayBetween(cmds.collect{ secureCmd(it) }, shortDelay)
-//}
-
-def toggle() {	
-    def toggleDirection = device.currentValue("switch")=="off"?"off->on":"on->off"
-    if (infoEnable) log.info "${device.displayName} toggle(${toggleDirection})"
-    state.lastCommandSent =                        "toggle(${toggleDirection})"
-    state.lastCommandTime = nowFormatted()
-    def cmds = []
-    cmds += zigbee.command(CLUSTER_ON_OFF, COMMAND_TOGGLE)
-    //// if having trouble keeping multiple bulbs in sync then comment-out the toggle command
-	//// and use the below code to emulate toggle with on/off commands
-    //if (device.currentValue("switch")=="off") {
-	//	if (settings.parameter23?.toInteger()>0) {
-	//		cmds += quickStart()  //IF quickStart is enabled THEN quickStart
-	//	} else {
-	//		cmds += zigbee.on(shortDelay)
-	//	}
-	//} else {
-	//	cmds += zigbee.off(shortDelay)
-	//}
-    if (debugEnable) log.debug "${device.displayName} toggle $cmds"
-    return cmds
-}
-
-def updated(option) { // called when "Save Preferences" is requested
-    option = (option==null||option==" ")?"":option
-    if (infoEnable) log.info "${device.displayName} updated(${option})"
-    state.lastCommandSent =                        "updated(${option})"
-    state.lastCommandTime = nowFormatted()
-    def cmds = []
-    def nothingChanged = true
-    int defaultValue
-    int newValue
-	configParams.each {	//loop through all parameters
-		int i = it.value.number.toInteger()
-		newValue = calculateParameter(i)
-		defaultValue=getDefaultValue(i)
-		if ([9,10,13,14,15,55,56].contains(i)) defaultValue=convertPercentToByte(defaultValue) //convert percent values back to byte values
-		if ((i==95 && parameter95custom!=null)||(i==96 && parameter96custom!=null)) {                                         //IF   a custom hue value is set
-			if ((Math.round(settings?."parameter${i}custom"?.toInteger()/360*255)==settings?."parameter${i}"?.toInteger())) { //AND  custom setting is same as normal setting
-				device.removeSetting("parameter${i}custom")                                                                   //THEN clear custom hue and use normal color 
-				if (infoEnable||traceEnable||debugEnable) log.info "${device.displayName} Cleared Custom Hue setting since it equals standard color setting"
-			}
-		}
-		switch (option) {
-			case "":
-				if ((getParameterNumbers().contains(i))		//IF   this is a valid parameter for this device mode
-				&& (settings."parameter$i"!=null)			//AND  this is a non-default setting
-				&& (!getReadOnlyParams().contains(i))) {	//AND  this is not a read-only parameter
-					cmds += setParameter(i, newValue)		//THEN set the new value
-					nothingChanged = false
-				}
-				break
-			case "All":
-			case "Default":
-				if (option=="Default") newValue = defaultValue	//if user selected "Default" then set the new value to the default value
-				if (((i!=158)&&(i!=258))					//IF   we are not changing Switch Mode
-				&& (!getReadOnlyParams().contains(i))) {	//AND  this is not a read-only parameter
-					cmds += setParameter(i, newValue)		//THEN Set the new value
-					nothingChanged = false
-				} else {									//ELSE this is a read-only parameter or Switch Mode parameter
-					cmds += getParameter(i)					//so Get current value from device
-				}
-				break
-			default: 
-				if (traceEnable||debugEnable) log.error "${device.displayName} Unknown option 'updated($option)'"
-				break
-		}
-        if ((i==23)&&(state.model?.substring(0,5)!="VZM35")) {  //IF not Fan switch THEN manually update the quickStart state variables since Dimmer does not store these
-            quickStartVariables()
-		}
-    }
-    if (settings?.groupBinding1 && !state?.groupBinding1) {
-        bindGroup("bind",settings.groupBinding1?.toInteger())
-		//device.updateSetting("groupBinding1",[value:settings.groupBinding1?.toInteger(),type:"number"])
-		state.groupBinding1=settings.groupBinding1?.toInteger()
-        nothingChanged = false
-    } else {
-        if (!settings?.groupBinding1 && state?.groupBinding1) {
-            bindGroup("unbind",state.groupBinding1?.toInteger())
-			device.removeSetting("groupBinding1")
-			state.groupBinding1=null
-            nothingChanged = false
-        }
-    }
-    if (settings?.groupBinding2 && !state?.groupBinding2) {
-        bindGroup("bind",settings.groupBinding2?.toInteger())
-		//device.updateSetting("groupBinding2",[value:settings.groupBinding2?.toInteger(),type:"number"])
-		state.groupBinding2=settings.groupBinding2?.toInteger()
-        nothingChanged = false
-    } else {
-        if (!settings?.groupBinding2 && state?.groupBinding2) {
-            bindGroup("unbind",state.groupBinding2?.toInteger())
-			device.removeSetting("groupBinding2")
-			state.groupBinding2=null
-            nothingChanged = false
-        }
-    }
-    if (settings?.groupBinding3 && !state?.groupBinding3) {
-        bindGroup("bind",settings.groupBinding3?.toInteger())
-		//device.updateSetting("groupBinding3",[value:state.groupBinding3?.toInteger(),type:"number"])
-		state.groupBinding3=state.groupBinding3?.toInteger()
-        nothingChanged = false
-    } else {
-        if (!settings?.groupBinding3 && state?.groupBinding3) {
-            bindGroup("unbind",state.groupBinding3?.toInteger())
-			device.removeSetting("groupBinding3")
-			state.groupBinding3=null
-            nothingChanged = false
-        }
-    }
-	// remove duplicate groups
-	if (settings.groupBinding3!=null && settings.groupBinding3==settings.groupBinding2) {device.removeSetting("groupBinding3"); state.groupBinding3 = null; if (infoEnable) log.info "${device.displayName} Removed duplicate Group Bind #3"}
-	if (settings.groupBinding2!=null && settings.groupBinding2==settings.groupBinding1) {device.removeSetting("groupBinding2"); state.groupBinding2 = null; if (infoEnable) log.info "${device.displayName} Removed duplicate Group Bind #2"}
-	if (settings.groupBinding1!=null && settings.groupBinding1==settings.groupBinding3) {device.removeSetting("groupBinding3"); state.groupBinding3 = null; if (infoEnable) log.info "${device.displayName} Removed duplicate Group Bind #3"}
-	
-    if (nothingChanged && (infoEnable||traceEnable||debugEnable)) log.info "${device.displayName} No DEVICE settings were changed"
-	log.info  "${device.displayName} Info logging  " + (infoEnable?limeGreen("Enabled"):red("Disabled"))
-	log.trace "${device.displayName} Trace logging " + (traceEnable?limeGreen("Enabled"):red("Disabled"))
-	log.debug "${device.displayName} Debug logging " + (debugEnable?limeGreen("Enabled"):red("Disabled"))
-
-    if (infoEnable && disableInfoLogging) {
-		log.info "${device.displayName} Info Logging will be disabled in $disableInfoLogging minutes"
-		runIn(disableInfoLogging*60,infoLogsOff)
-	}
-    if (traceEnable && disableTraceLogging) {
-		log.trace "${device.displayName} Trace Logging will be disabled in $disableTraceLogging minutes"
-		runIn(disableTraceLogging*60,traceLogsOff)
-	}
-    if (debugEnable && disableDebugLogging) {
-		log.debug "${device.displayName} Debug Logging will be disabled in $disableDebugLogging minutes"
-		runIn(disableDebugLogging*60,debugLogsOff) 
-	}
-    return cmds
-}
-
-List updateFirmware() {
-    if (infoEnable) log.info "${device.displayName} updateFirmware(switch's fwDate: ${state.fwDate}, switch's fwVersion: ${state.fwVersion})"
-    state.lastCommandSent =                        "updateFirmware()"
-    state.lastCommandTime = nowFormatted()
-    def cmds = []
-    //if (state?.lastUpdateFw && now() - state.lastUpdateFw < 2000) {
-	//	state.remove("lastUpdateFw")
-        cmds += zigbee.updateFirmware()
-        if (debugEnable) log.debug "${device.displayName} updateFirmware $cmds"
-    //} else {
-    //    log.warn "Firmware in this channel may be \"beta\" quality. Please check https://community.inovelli.com/t/blue-series-2-1-firmware-changelog-vzm31-sn/12326 before proceeding. Double-click \"Update Firmware\" to proceed"
-	//	state.lastUpdateFw = now()
-	//	runIn(2,lastUpdateFwRemove)
-    //}
-    return cmds
-}
-//def lastUpdateFwRemove() {if (state?.lastUpdateFw) state.remove("lastUpdateFw")}
-
-void ZigbeePrivateCommandEvent(data) {
-    if (infoEnable) log.info "${device.displayName} SceneButton=${data[0]} ButtonAttributes=${data[1]}"
-    Integer ButtonNumber = Integer.parseInt(data[0],16)
-    Integer ButtonAttributes = Integer.parseInt(data[1],16)
-    switch(zigbee.convertToHexString(ButtonNumber,2) + zigbee.convertToHexString(ButtonAttributes,2)) {
-        case "0200":    //Tap Up 1x
-            //if (state.model?.substring(0,5)!="VZM35") quickStart()  //If not Fan then emulate quickStart for local button push (this doesn't appear to work - not sure why)
-            buttonEvent(1, "pushed", "physical")
-            break
-        case "0203":    //Tap Up 2x
-            buttonEvent(2, "pushed", "physical")
-            break
-        case "0204":    //Tap Up 3x
-            buttonEvent(3, "pushed", "physical")
-            break
-        case "0205":    //Tap Up 4x
-            buttonEvent(4, "pushed", "physical")
-            break
-        case "0206":    //Tap Up 5x
-            buttonEvent(5, "pushed", "physical")
-            break
-        case "0202":    //Hold Up
-            buttonEvent(6, "pushed", "physical")
-            break
-        case "0201":    //Release Up
-            buttonEvent(7, "pushed", "physical")
-            break
-        case "0100":    //Tap Down 1x
-            buttonEvent(1, "held", "physical")
-            break
-        case "0103":    //Tap Down 2x
-            buttonEvent(2, "held", "physical")
-            break
-        case "0104":    //Tap Down 3x
-            buttonEvent(3, "held", "physical")
-            break
-        case "0105":    //Tap Down 4x
-            buttonEvent(4, "held", "physical")
-            break
-        case "0106":    //Tap Down 5x
-            buttonEvent(5, "held", "physical")
-            break
-        case "0102":    //Hold Down
-            buttonEvent(6, "held", "physical")
-            break
-        case "0101":    //Release Down
-            buttonEvent(7, "held", "physical")
-            break
-        case "0300":    //Tap Config 1x
-            buttonEvent(8, "pushed", "physical")
-            break
-        case "0303":    //Tap Config 2x
-            buttonEvent(9, "pushed", "physical")
-            break
-        case "0304":    //Tap Config 3x
-            buttonEvent(10, "pushed", "physical")
-            break
-        case "0305":    //Tap Config 4x
-            buttonEvent(11, "pushed", "physical")
-            break
-        case "0306":    //Tap Config 5x
-            buttonEvent(12, "pushed", "physical")
-            break
-        case "0302":    //Hold Config
-            buttonEvent(13, "pushed", "physical")
-            break
-        case "0301":    //Release Config
-            buttonEvent(14, "pushed", "physical")
-            break
-        default:       //undefined button function
-            log.warn "${device.displayName} " + fireBrick("Undefined button function Scene=${data[0]} Attributes=${data[1]}")
-            break
-    }
-}
-
-void ZigbeePrivateLEDeffectStopEvent(data) {
-    Integer ledNumber = Integer.parseInt(data[0],16)+1 //internal LED number is 0-based
-    String  ledStatus = ledNumber==17?"Stop All":ledNumber==256?"User Cleared":"Stop LED${ledNumber}"
-    if (infoEnable) log.info "${device.displayName} ledEffectStopEvent=${ledStatus}"
-	switch(ledNumber){
-        case 1:
-        case 2:
-        case 3:
-        case 4:
-        case 5:
-        case 6:
-        case 7:
-        case 17:  //Full LED bar effects
-        case 256: //user double-pressed the config button to clear the notification
-			sendEvent(name:"ledEffect", value: "${ledStatus}")
-            break
-        default:  
-			log.warn "${device.displayName} " + fireBrick("Undefined LEDeffectStopEvent=${data[0]}")
-            break
-    }
-}
-
-void buttonEvent(button, action, type = "digital") {
-    if (infoEnable) log.info "${device.displayName} ${type} Button ${button} was ${action}"
-    sendEvent(name: action, value: button, isStateChange: true, type: type)
-    switch (button) {
-        case 1:
-        case 2:
-        case 3:
-        case 4:
-        case 5:
-            sendEvent(name:"lastButton", value: "${action=='pushed'?'Tap '.padRight(button+4, '▲'):'Tap '.padRight(button+4, '▼')}")
-            break
-        case 6:
-            sendEvent(name:"lastButton", value: "${action=='pushed'?'Hold ▲':'Hold ▼'}")
-            break
-        case 7:
-            sendEvent(name:"lastButton", value: "${action=='pushed'?'Release ▲':'Release ▼'}")
-            break
-        case 8:
-        case 9:
-        case 10:
-        case 11:
-        case 12:
-            sendEvent(name:"lastButton", value: "Tap ".padRight(button-3, "►"))
-            break
-        case 13:
-            sendEvent(name:"lastButton", value: "Hold ►")
-            break
-        case 14:
-            sendEvent(name:"lastButton", value: "Release ►")
-            break
-    }
-}
-
-void hold(button)    {buttonEvent(button, "held", "digital")}
-void push(button)    {buttonEvent(button, "pushed", "digital")}
-void release(button) {buttonEvent(button, "released", "digital")}
-
-def pressUpX1()      {buttonEvent(1, "pushed", "digital")}
-def pressDownX1()    {buttonEvent(1, "held", "digital")}
-def pressUpX2()      {buttonEvent(2, "pushed", "digital")}
-def pressDownX2()    {buttonEvent(2, "held", "digital")}
-def pressUpX3()      {buttonEvent(3, "pushed", "digital")}
-def pressDownX3()    {buttonEvent(3, "held", "digital")}
-def pressUpX4()      {buttonEvent(4, "pushed", "digital")}
-def pressDownX4()    {buttonEvent(4, "held", "digital")}
-def pressUpX5()      {buttonEvent(5, "pushed", "digital")}
-def pressDownX5()    {buttonEvent(5, "held", "digital")}
-def holdUp()         {buttonEvent(6, "pushed", "digital")}
-def holdDown()       {buttonEvent(6, "held", "digital")}
-def releaseUp()      {buttonEvent(7, "pushed", "digital")}
-def releaseDown()    {buttonEvent(7, "held", "digital")}
-def pressConfigX1()  {buttonEvent(8, "pushed", "digital")}
-def pressConfigX2()  {buttonEvent(9, "pushed", "digital")}
-def pressConfigX3()  {buttonEvent(10, "pushed", "digital")}
-def pressConfigX4()  {buttonEvent(11, "pushed", "digital")}
-def pressConfigX5()  {buttonEvent(12, "pushed", "digital")}
-def holdConfig()     {buttonEvent(13, "held", "digital")}
-def releaseConfig()  {buttonEvent(14, "released", "digital")}
 
 /**
  *  -----------------------------------------------------------------------------


### PR DESCRIPTION
By request, remove the code that automatically binds the switch to zigbee groups.   Switch will have to be manually bound to the group if desired